### PR TITLE
docs: state that this mirror does not accept pull requests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!--
+  Please read before submitting.
+
+  This repository does not accept pull requests. It is a mirror: development
+  happens in a private tree and is published here on each release, so there is
+  nowhere for a PR to land — it would be overwritten by the next sync.
+
+  This is not about the quality of your work. If you open one anyway, we will
+  close it with a link to CONTRIBUTING.md.
+
+  What helps instead:
+
+    • Bugs and feature requests → open an issue
+      https://github.com/OpenMinis/OpenMinis/issues
+
+    • Use cases and workflows   → OpenMinis/AwesomeMinis  (accepts PRs)
+    • Skills                    → OpenMinis/MinisSkills   (accepts PRs)
+    • Questions and discussion  → the Telegram group, linked in the README
+
+  See CONTRIBUTING.md for the full picture.
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+Thanks for your interest in Minis.
+
+## We do not accept pull requests
+
+This repository is a **mirror**. Development happens in a private tree and is
+published here on each release, so a pull request opened against this
+repository has nowhere to land — merging it would be overwritten by the next
+sync, and we cannot merge it upstream either.
+
+Please do not spend your time preparing one. If you have already opened a PR,
+we will close it with a pointer back to this document; that is not a judgement
+on the work.
+
+## What we do want
+
+Everything else. The product is shaped by what people report:
+
+- **[Open an issue](https://github.com/OpenMinis/OpenMinis/issues)** — bugs,
+  crashes, papercuts, feature requests, questions about behaviour. A clear
+  report is worth more to us than a patch, because it tells us what to build.
+- **Share what you have built** — real workflows and use cases go in
+  **[AwesomeMinis](https://github.com/OpenMinis/AwesomeMinis)**, which does
+  take contributions.
+- **Write a skill** — **[MinisSkills](https://github.com/OpenMinis/MinisSkills)**
+  also takes contributions, and skills are how most people extend Minis
+  without touching the app at all.
+- **Talk to us** — the [Telegram group](https://t.me/+2NzhOJuzRyI1YmM1) is
+  where most day-to-day discussion happens.
+
+## Filing a good issue
+
+The more of this you can give us, the faster it gets fixed:
+
+- Platform and version (Settings → About shows both)
+- What you expected, what happened instead
+- Steps to reproduce, or the prompt that triggered it
+- Which model / provider was selected, if relevant
+- Logs, if the app produced any (Settings → Logs)
+
+## Using the source
+
+The code is GPLv3. You are free to fork it, modify it and run your own build —
+see [BUILDING.md](BUILDING.md). The licence obliges you to publish the source
+of anything you distribute, and to keep it under GPLv3.
+
+We simply do not merge changes back through this repository.

--- a/README.md
+++ b/README.md
@@ -209,3 +209,9 @@ work is distributed under GPLv3. Bundled third-party licenses are listed in
 - **Telegram**: [Join the group](https://t.me/+2NzhOJuzRyI1YmM1)
 - **Issues**: Bug reports, feature requests and discussion via
   [GitHub Issues](https://github.com/OpenMinis/OpenMinis/issues)
+
+This repository is a mirror of a private development tree, so it **does not
+accept pull requests** — there is nowhere for them to land. Issues are the way
+to shape the product, and [AwesomeMinis](https://github.com/OpenMinis/AwesomeMinis)
+and [MinisSkills](https://github.com/OpenMinis/MinisSkills) both do take
+contributions. See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
Development happens in a private tree and is published here on each release, so a pull request opened against this repository has nowhere to land — the next sync would overwrite it, and it cannot be merged upstream either. Better to say so up front than to let someone prepare a patch and then close it.

Three places, each catching a different moment:

- **`CONTRIBUTING.md`** — the full explanation
- **`.github/pull_request_template.md`** — shows up while composing a PR, the last point at which the effort can be saved
- **README, Community section** — a short note for anyone who never opens either file

Each one redirects rather than just refusing. Issues are what shape the product, and [AwesomeMinis](https://github.com/OpenMinis/AwesomeMinis) and [MinisSkills](https://github.com/OpenMinis/MinisSkills) genuinely do take contributions. `CONTRIBUTING.md` also spells out what makes an issue actionable, and reiterates that GPLv3 lets anyone fork and build — we simply do not merge changes back through here.