### PR TITLE
feat(browser): 嵌入 Chromium Blink+V8 引擎（iOS 16 真实渲染）

### DIFF
--- a/.github/workflows/blink-build.yml
+++ b/.github/workflows/blink-build.yml
@@ -1,0 +1,218 @@
+name: Blink Engine Build (Chromium + OpenMinis IPA/TIPA)
+
+on:
+  workflow_dispatch:
+    inputs:
+      chromium_build:
+        description: '仅构建 Chromium（跳过 OpenMinis 打包）'
+        required: false
+        default: false
+        type: boolean
+  push:
+    branches: [main]
+    paths:
+      - 'chromium-blink/**'
+      - '.github/workflows/blink-build.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  build-chromium:
+    name: Build Chromium Blink (content_shell_framework)
+    runs-on: macos-15
+    timeout-minutes: 355
+    env:
+      CHROMIUM_BUILDTOOLS_PATH: ${{ github.workspace }}/chromium/src/buildtools
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+
+    steps:
+      - name: Install ccache (incremental Chromium builds)
+        run: |
+          brew install ccache 2>/dev/null || brew upgrade ccache 2>/dev/null || true
+          ccache -M 8G
+          ccache -z
+
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/.ccache
+          key: ccache-${{ runner.os }}-${{ hashFiles('chromium-blink/**', '.github/workflows/blink-build.yml') }}
+          restore-keys: |
+            ccache-${{ runner.os }}-
+
+      - name: Free disk space
+        run: |
+          # --- Simulators: not needed for device builds ---
+          sudo rm -rf ~/Library/Developer/CoreSimulator/Devices/* 2>/dev/null || true
+          sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS* 2>/dev/null || true
+          sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/watchOS* 2>/dev/null || true
+          sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS* 2>/dev/null || true
+          sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/xrOS* 2>/dev/null || true
+          # --- Heavy SDKs / toolchains (NOT Xcode — image default is the usable one) ---
+          sudo rm -rf /usr/local/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost 2>/dev/null || true
+          sudo rm -rf ~/.gradle ~/.m2 ~/.npm ~/.cache/pip /Users/runner/Library/Android 2>/dev/null || true
+          sudo rm -rf ~/Library/Caches/Homebrew 2>/dev/null || true
+          brew cleanup --prune=all 2>/dev/null || true
+          echo "==> Free space after cleanup:"
+          df -h /
+
+      - name: Select Xcode (use image default — safest for Chromium 149)
+        run: |
+          echo "Active: $(xcode-select -p)"
+          xcodebuild -version
+
+      - uses: actions/checkout@v4
+
+      - name: Clone Blinker Fluid (patch set)
+        run: |
+          git clone --depth 1 https://github.com/Ssabal/blinker-fluid.git blinker-fluid
+          ls blinker-fluid
+
+      - name: Fetch + patch Chromium (shallow, ~30-50 min)
+        run: |
+          chmod +x chromium-blink/fetch_and_patch.sh
+          ./chromium-blink/fetch_and_patch.sh "$PWD" "$PWD/blinker-fluid" 2>&1 | tail -40
+          df -h /
+
+      - name: Check free disk (hard fail below 50GB — Chromium build + runner log spool)
+        run: |
+          FREE=$(df -k / | awk 'NR==2 {print $4}')
+          echo "free_kb=$FREE  free_gb=$((FREE/1024/1024))"
+          if [ "$FREE" -lt 50000000 ]; then
+            echo "::error::Only $((FREE/1024/1024)) GB free — Chromium static build needs ~50GB. Aborting to avoid a disk-full wedge."
+            exit 1
+          fi
+
+      - name: Build content_shell (1.5-3 h)
+        run: |
+          cd chromium/src
+          # Disk watchdog: abort cleanly instead of wedging the runner on a full
+          # disk (the previous run froze silently for 1h42m when the volume filled).
+          ( while true; do
+              FREE=$(df -k / | awk 'NR==2 {print $4}')
+              if [ "$FREE" -lt 3000000 ]; then
+                echo "::error::DISK FULL (free=$((FREE/1024/1024))MB) — aborting ninja"
+                pkill -9 -f 'ninja -C out/Release-iphoneos' 2>/dev/null || true
+                exit 1
+              fi
+              sleep 90
+            done ) &
+          WATCHDOG=$!
+          echo "Build start: $(date)"
+          autoninja -C out/Release-iphoneos content_shell
+          RC=$?
+          kill $WATCHDOG 2>/dev/null || true
+          echo "Build end: $(date) rc=$RC"
+          exit $RC
+
+      - name: Collect engine artifacts
+        run: |
+          OUT=chromium/src/out/Release-iphoneos
+          APP=$(find "$OUT" -name "content_shell.app" -type d | head -1)
+          if [ -z "$APP" ]; then
+            echo "!! content_shell.app not found in $OUT"
+            find "$OUT" -maxdepth 3 -name "*.app" -type d
+            exit 1
+          fi
+          echo "found app: $APP"
+          mkdir -p /tmp/blink-artifacts
+          # The built app bundle contains the exact runtime layout (framework +
+          # icudtl.dat + paks + fonts + net/ + locales) — ship it whole.
+          cp -R "$APP" /tmp/blink-artifacts/content_shell.app
+          # Version stamp
+          echo "${{ github.sha }}" > /tmp/blink-artifacts/BLINK_BUILD.txt
+          echo "$(date -u +%Y%m%d-%H%M%S)" >> /tmp/blink-artifacts/BLINK_BUILD.txt
+          du -sh /tmp/blink-artifacts/content_shell.app
+
+      - name: Upload Chromium artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: blink-engine
+          path: /tmp/blink-artifacts
+          compression-level: 1
+          retention-days: 14
+
+  build-minis:
+    name: Build OpenMinis IPA/TIPA (TrollStore)
+    runs-on: macos-14
+    needs: build-chromium
+    if: ${{ !inputs.chromium_build }}
+    timeout-minutes: 120
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: |
+          sudo xcode-select -s /Applications/Xcode_16.2.app 2>/dev/null \
+            || sudo xcode-select -s /Applications/Xcode_16.1.app 2>/dev/null \
+            || sudo xcode-select -s /Applications/Xcode_16.app 2>/dev/null \
+            || sudo xcode-select -s /Applications/Xcode_15.4.app 2>/dev/null \
+            || true
+          xcodebuild -version
+
+      - name: Download Chromium engine
+        uses: actions/download-artifact@v4
+        with:
+          name: blink-engine
+          path: blink-engine
+
+      - name: List schemes
+        run: xcodebuild -project src/ios/Minis.xcodeproj -list | head -30
+
+      - name: Build Minis (unsigned, TrollStore-compatible)
+        run: |
+          xcodebuild build \
+            -project src/ios/Minis.xcodeproj \
+            -scheme Minis \
+            -sdk iphoneos \
+            -configuration Release \
+            -derivedDataPath build/DerivedData \
+            CODE_SIGN_IDENTITY="" \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
+            ONLY_ACTIVE_ARCH=NO \
+            -destination 'generic/platform=iOS' 2>&1 | tail -25
+          APP=$(find build/DerivedData -name "Minis.app" -type d | head -1)
+          echo "APP=$APP"
+          [ -n "$APP" ] || { echo "!! Minis.app not found"; exit 1; }
+
+      - name: Embed Blink engine into app bundle
+        run: |
+          APP=$(find build/DerivedData -name "Minis.app" -type d | head -1)
+          chmod +x chromium-blink/embed_into_app.sh
+          ./chromium-blink/embed_into_app.sh "$APP" "blink-engine/content_shell.app"
+          echo "==> App size: $(du -sh "$APP" | cut -f1)"
+
+      - name: Package IPA + TIPA
+        run: |
+          APP=$(find build/DerivedData -name "Minis.app" -type d | head -1)
+          chmod +x scripts/package_tipa.sh
+          ./scripts/package_tipa.sh "$APP" "$PWD/dist"
+
+      - name: Upload IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenMinis-Blink-IPA
+          path: dist/*.ipa
+          retention-days: 30
+
+      - name: Upload TIPA (TrollStore)
+        uses: actions/upload-artifact@v4
+        with:
+          name: OpenMinis-Blink-TIPA
+          path: dist/*.tipa
+          retention-days: 30
+
+      - name: Build summary
+        if: always()
+        run: |
+          {
+            echo "## OpenMinis Blink Build"
+            echo "- 引擎: Chromium Blink+V8 (use_blink=true, JITless, 单进程)"
+            echo "- iOS: 16.0+ (arm64), TrollStore 免签名"
+            echo "- 安装: 下载 TIPA → TrollStore 安装 → 浏览器工具栏引擎菜单选 Blink"
+            echo "- 降级: 引擎菜单 SSR / 系统浏览器打开 (P1/P2)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/chromium-blink/bridge/blink_bridge.h
+++ b/chromium-blink/bridge/blink_bridge.h
@@ -1,0 +1,88 @@
+// blink_bridge.h — C API between the OpenMinis iOS app and the embedded
+// Chromium Blink engine (content_shell_framework.framework).
+//
+// All functions must be called on the main thread. Callbacks are invoked
+// synchronously on the main thread; the pointer passed to the callback is
+// valid only for the duration of the call (copy it immediately).
+#ifndef BLINK_BRIDGE_H_
+#define BLINK_BRIDGE_H_
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Opaque handle to one Blink tab/view.
+typedef struct BlinkBridgeView BlinkBridgeView;
+
+// Callback invoked with a JSON string payload (see events below).
+typedef void (*BlinkBridgeCallback)(void* ctx, const char* payload);
+
+// One-time browser-process initialization. Must be called once, on the main
+// thread, before creating any view. `bundle_path` and `tmp_path` are used for
+// resource/log path hints (may be NULL). Returns 0 on success.
+int BlinkBridgeInitialize(const char* bundle_path, const char* tmp_path);
+
+// Create a Blink-rendered view of the given size. Returns an opaque handle,
+// or NULL on failure. The view's UIView is returned by BlinkBridgeGetNativeView.
+BlinkBridgeView* BlinkBridgeCreateView(int width, int height);
+
+// Returns the UIView backing the view (borrowed — do not free).
+void* BlinkBridgeGetNativeView(BlinkBridgeView* view);
+
+// Resize the view (call on layout).
+void BlinkBridgeSetViewFrame(BlinkBridgeView* view, int x, int y, int w, int h);
+
+// Navigation.
+void BlinkBridgeLoadURL(BlinkBridgeView* view, const char* url);
+void BlinkBridgeGoBack(BlinkBridgeView* view);
+void BlinkBridgeGoForward(BlinkBridgeView* view);
+void BlinkBridgeReload(BlinkBridgeView* view);
+void BlinkBridgeStop(BlinkBridgeView* view);
+
+// Evaluate JavaScript in the page's main world. `cb` receives a JSON payload:
+//   {"ok":true,"value":<json>} | {"ok":true} | {"ok":false,"error":"..."}
+void BlinkBridgeEvaluateJS(BlinkBridgeView* view,
+                           const char* js,
+                           BlinkBridgeCallback cb,
+                           void* ctx);
+
+// Capture the current view as a PNG. `cb` receives {"ok":true,"png_base64":"..."}
+// or {"ok":false,"error":"..."}.
+void BlinkBridgeCaptureSnapshot(BlinkBridgeView* view,
+                                BlinkBridgeCallback cb,
+                                void* ctx);
+
+// State getters (returned strings are static/borrowed — copy immediately).
+const char* BlinkBridgeGetURL(BlinkBridgeView* view);
+const char* BlinkBridgeGetTitle(BlinkBridgeView* view);
+int BlinkBridgeIsLoading(BlinkBridgeView* view);
+int BlinkBridgeCanGoBack(BlinkBridgeView* view);
+int BlinkBridgeCanGoForward(BlinkBridgeView* view);
+
+// Per-view UA override (applies to subsequent navigations).
+void BlinkBridgeSetUserAgent(BlinkBridgeView* view, const char* ua);
+
+// Install the event callback for a view (replaces any previous one).
+// Event payloads:
+//   {"event":"didStartProvisionalNavigation","url":"..."}
+//   {"event":"didFinishNavigation","url":"..."}
+//   {"event":"didFailNavigation","url":"...","error":"..."}
+//   {"event":"loadingStateChanged","loading":true|false}
+//   {"event":"renderProcessGone"}
+void BlinkBridgeSetEventCallback(BlinkBridgeView* view,
+                                 BlinkBridgeCallback cb,
+                                 void* ctx);
+
+// Destroy the view and its shell. Safe to call once.
+void BlinkBridgeDestroyView(BlinkBridgeView* view);
+
+// Last error message (static buffer, for diagnostics).
+const char* BlinkBridgeLastError(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // BLINK_BRIDGE_H_

--- a/chromium-blink/bridge/blink_bridge.mm
+++ b/chromium-blink/bridge/blink_bridge.mm
@@ -1,0 +1,448 @@
+// blink_bridge.mm — embed implementation of the blink_bridge C API.
+//
+// Compiled into content_shell_framework.framework (added to content/shell
+// BUILD.gn as source_set("blink_bridge")). Embeds Chromium's browser process
+// into a host app (OpenMinis): BlinkBridgeInitialize runs the content main
+// (single-process, in-process renderer per Blinker Fluid's patches), and each
+// BlinkBridgeCreateView creates a content::Shell whose WebContents view is
+// handed to the host for embedding.
+
+#import <UIKit/UIKit.h>
+
+#include <memory>
+#include <string>
+
+#include "base/command_line.h"
+#include "base/functional/bind.h"
+#include "base/json/write_json.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/sys_string_conversions.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/values.h"
+#include "content/public/app/content_main.h"
+#include "content/public/app/content_main_runner.h"
+#include "content/public/browser/navigation_handle.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "content/shell/app/shell_main_delegate.h"
+#include "content/shell/browser/shell.h"
+#include "content/shell/browser/shell_content_browser_client.h"
+#include "net/base/net_errors.h"
+#include "third_party/blink/public/common/isolated_worlds/isolated_world_ids.h"
+#include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
+#include "ui/gfx/geometry/size.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+#include "content/shell/bridge/blink_bridge.h"
+
+namespace {
+
+// Last diagnostic error.
+std::string g_last_error;
+
+void SetError(const char* message) {
+  g_last_error = message ? message : "unknown";
+  if (message) {
+    NSLog(@"BlinkBridge: %s", message);
+  }
+}
+
+// Synthesized command line. --blink-embed makes ShellBrowserMainParts skip
+// auto-creating windows (host app creates shells on demand); --js-flags=--jitless
+// keeps V8 in interpreter mode (stable on iOS, per Blinker Fluid).
+const char* const kEmbedArgv[] = {
+    "Minis",
+    "--blink-embed",
+    "--js-flags=--jitless",
+    nullptr,
+};
+const int kEmbedArgc = 3;
+
+std::unique_ptr<content::ContentMainRunner> g_main_runner;
+std::unique_ptr<content::ShellMainDelegate> g_main_delegate;
+
+// ---------------------------------------------------------------------------
+// WebContentsObserver forwarding navigation events to the host app.
+// ---------------------------------------------------------------------------
+
+class BlinkBridgeObserver : public content::WebContentsObserver {
+ public:
+  BlinkBridgeObserver(content::WebContents* web_contents, BlinkBridgeView* view)
+      : content::WebContentsObserver(web_contents), view_(view) {}
+
+  void DidStartNavigation(
+      content::NavigationHandle* navigation_handle) override {
+    if (!navigation_handle->IsInMainFrame()) {
+      return;
+    }
+    Emit("didStartProvisionalNavigation",
+         navigation_handle->GetURL().spec().c_str());
+  }
+
+  void DidFinishNavigation(
+      content::NavigationHandle* navigation_handle) override {
+    if (!navigation_handle->IsInMainFrame()) {
+      return;
+    }
+    if (navigation_handle->GetNetErrorCode() != net::OK) {
+      std::string payload = "{\"event\":\"didFailNavigation\",\"url\":\"";
+      payload += JsonEscape(navigation_handle->GetURL().spec());
+      payload += "\",\"error\":\"";
+      payload += JsonEscape(net::ErrorToString(navigation_handle->GetNetErrorCode()));
+      payload += "\"}";
+      EmitRaw(payload.c_str());
+      return;
+    }
+    if (navigation_handle->HasCommitted()) {
+      Emit("didFinishNavigation", navigation_handle->GetURL().spec().c_str());
+    }
+  }
+
+  void DidStartLoading() override {
+    EmitBool("loadingStateChanged", true);
+  }
+
+  void DidStopLoading() override {
+    EmitBool("loadingStateChanged", false);
+  }
+
+  void RenderProcessGone(const content::ChildProcessTerminationInfo& info) override {
+    EmitRaw("{\"event\":\"renderProcessGone\"}");
+  }
+
+ private:
+  BlinkBridgeView* view_;
+
+  static std::string JsonEscape(const std::string& input) {
+    std::string out;
+    for (char c : input) {
+      switch (c) {
+        case '"': out += "\\\""; break;
+        case '\\': out += "\\\\"; break;
+        case '\n': out += "\\n"; break;
+        case '\r': out += "\\r"; break;
+        case '\t': out += "\\t"; break;
+        default:
+          if (static_cast<unsigned char>(c) < 0x20) {
+            char buf[8];
+            snprintf(buf, sizeof(buf), "\\u%04x", c);
+            out += buf;
+          } else {
+            out += c;
+          }
+      }
+    }
+    return out;
+  }
+
+  void Emit(const char* event, const char* url) {
+    std::string payload = "{\"event\":\"";
+    payload += event;
+    payload += "\",\"url\":\"";
+    payload += JsonEscape(url ? url : "");
+    payload += "\"}";
+    EmitRaw(payload.c_str());
+  }
+
+  void EmitBool(const char* event, bool value) {
+    std::string payload = "{\"event\":\"";
+    payload += event;
+    payload += "\",\"loading\":";
+    payload += value ? "true" : "false";
+    payload += "}";
+    EmitRaw(payload.c_str());
+  }
+
+  void EmitRaw(const char* payload) {
+    if (!view_ || !view_->event_cb) {
+      return;
+    }
+    view_->event_cb(view_->event_ctx, payload);
+  }
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Bridge view (one per tab).
+// ---------------------------------------------------------------------------
+
+struct BlinkBridgeView {
+  content::Shell* shell = nullptr;
+  UIView* native_view = nil;
+  std::unique_ptr<BlinkBridgeObserver> observer;
+  BlinkBridgeCallback event_cb = nullptr;
+  void* event_ctx = nullptr;
+  std::string pending_ua;
+};
+
+// ---------------------------------------------------------------------------
+// C API
+// ---------------------------------------------------------------------------
+
+extern "C" {
+
+int BlinkBridgeInitialize(const char* bundle_path, const char* tmp_path) {
+  if (g_main_runner) {
+    return 0;  // already initialized
+  }
+
+  @autoreleasepool {
+    g_main_delegate = std::make_unique<content::ShellMainDelegate>();
+    content::ContentMainParams params(g_main_delegate.get());
+    params.argc = kEmbedArgc;
+    params.argv = kEmbedArgv;
+    g_main_runner = content::ContentMainRunner::Create();
+    int rv = content::RunContentProcess(std::move(params), g_main_runner.get());
+    if (rv != 0) {
+      SetError("RunContentProcess failed");
+      return rv;
+    }
+  }
+  return 0;
+}
+
+BlinkBridgeView* BlinkBridgeCreateView(int width, int height) {
+  content::ShellContentBrowserClient* client =
+      content::ShellContentBrowserClient::Get();
+  if (!client || !client->browser_context()) {
+    SetError("BlinkBridgeCreateView: browser context not ready");
+    return nullptr;
+  }
+
+  content::Shell* shell = content::Shell::CreateNewWindow(
+      client->browser_context(), GURL(url::kAboutBlankURL), nullptr,
+      gfx::Size(width, height));
+  if (!shell || !shell->web_contents()) {
+    SetError("BlinkBridgeCreateView: Shell::CreateNewWindow failed");
+    return nullptr;
+  }
+
+  auto* view = new BlinkBridgeView();
+  view->shell = shell;
+  view->native_view = shell->GetContentView();
+  if (!view->native_view) {
+    delete view;
+    SetError("BlinkBridgeCreateView: no native view");
+    return nullptr;
+  }
+  view->native_view.frame =
+      CGRectMake(0, 0, width > 0 ? width : 390, height > 0 ? height : 844);
+  view->observer = std::make_unique<BlinkBridgeObserver>(
+      shell->web_contents(), view);
+  return view;
+}
+
+void* BlinkBridgeGetNativeView(BlinkBridgeView* view) {
+  return view ? (__bridge void*)view->native_view : nullptr;
+}
+
+void BlinkBridgeSetViewFrame(BlinkBridgeView* view,
+                             int x, int y, int w, int h) {
+  if (!view || !view->native_view) {
+    return;
+  }
+  view->native_view.frame = CGRectMake(x, y, w, h);
+}
+
+void BlinkBridgeLoadURL(BlinkBridgeView* view, const char* url) {
+  if (!view || !view->shell || !url) {
+    return;
+  }
+  GURL gurl(url);
+  if (!gurl.is_valid()) {
+    SetError("BlinkBridgeLoadURL: invalid URL");
+    return;
+  }
+  view->shell->LoadURL(gurl);
+}
+
+void BlinkBridgeGoBack(BlinkBridgeView* view) {
+  if (view && view->shell) {
+    view->shell->GoBackOrForward(-1);
+  }
+}
+
+void BlinkBridgeGoForward(BlinkBridgeView* view) {
+  if (view && view->shell) {
+    view->shell->GoBackOrForward(1);
+  }
+}
+
+void BlinkBridgeReload(BlinkBridgeView* view) {
+  if (view && view->shell) {
+    view->shell->Reload();
+  }
+}
+
+void BlinkBridgeStop(BlinkBridgeView* view) {
+  if (view && view->shell && view->shell->web_contents()) {
+    view->shell->web_contents()->Stop();
+  }
+}
+
+void BlinkBridgeEvaluateJS(BlinkBridgeView* view,
+                           const char* js,
+                           BlinkBridgeCallback cb,
+                           void* ctx) {
+  if (!view || !view->shell || !view->shell->web_contents() || !js) {
+    if (cb) {
+      cb(ctx, "{\"ok\":false,\"error\":\"no web contents\"}");
+    }
+    return;
+  }
+  content::RenderFrameHost* frame =
+      view->shell->web_contents()->GetPrimaryMainFrame();
+  if (!frame) {
+    if (cb) {
+      cb(ctx, "{\"ok\":false,\"error\":\"no main frame\"}");
+    }
+    return;
+  }
+
+  std::u16string script = base::SysUTF8ToUTF16(js);
+  frame->ExecuteJavaScriptForTests(
+      script,
+      base::BindOnce(
+          [](BlinkBridgeCallback cb, void* ctx, base::Value result) {
+            if (!cb) {
+              return;
+            }
+            if (result.is_none()) {
+              cb(ctx, "{\"ok\":true}");
+              return;
+            }
+            std::string json;
+            if (result.is_string()) {
+              json = result.GetString();
+            } else if (auto w = base::WriteJson(result)) {
+              json = *w;
+            } else {
+              json = result.is_bool()
+                         ? (result.GetBool() ? "true" : "false")
+                         : (result.is_int() ? base::NumberToString(result.GetInt())
+                                            : "\"<unserializable>\"");
+            }
+            std::string payload = "{\"ok\":true,\"value\":";
+            payload += json;
+            payload += "}";
+            cb(ctx, payload.c_str());
+          },
+          cb, ctx),
+      ISOLATED_WORLD_ID_GLOBAL);
+}
+
+void BlinkBridgeCaptureSnapshot(BlinkBridgeView* view,
+                                BlinkBridgeCallback cb,
+                                void* ctx) {
+  if (!view || !view->native_view) {
+    if (cb) {
+      cb(ctx, "{\"ok\":false,\"error\":\"no view\"}");
+    }
+    return;
+  }
+  UIView* v = view->native_view;
+  CGRect bounds = v.bounds;
+  if (bounds.size.width < 1 || bounds.size.height < 1) {
+    bounds = CGRectMake(0, 0, 390, 844);
+  }
+  UIGraphicsImageRenderer* renderer =
+      [[UIGraphicsImageRenderer alloc] initWithSize:bounds.size];
+  UIImage* image = [renderer imageWithActions:^(UIGraphicsImageRendererContext* ctx) {
+    [v drawViewHierarchyInRect:bounds afterScreenUpdates:YES];
+  }];
+  NSData* png = UIImagePNGRepresentation(image);
+  if (!png) {
+    if (cb) {
+      cb(ctx, "{\"ok\":false,\"error\":\"snapshot render failed\"}");
+    }
+    return;
+  }
+  NSString* b64 = [png base64EncodedStringWithOptions:0];
+  if (cb) {
+    std::string payload = "{\"ok\":true,\"png_base64\":\"";
+    payload += b64.UTF8String ? b64.UTF8String : "";
+    payload += "\"}";
+    cb(ctx, payload.c_str());
+  }
+}
+
+const char* BlinkBridgeGetURL(BlinkBridgeView* view) {
+  if (!view || !view->shell || !view->shell->web_contents()) {
+    return "";
+  }
+  const GURL& url = view->shell->web_contents()->GetVisibleURL();
+  static std::string cached;
+  cached = url.valid() ? url.spec() : "";
+  return cached.c_str();
+}
+
+const char* BlinkBridgeGetTitle(BlinkBridgeView* view) {
+  if (!view || !view->shell || !view->shell->web_contents()) {
+    return "";
+  }
+  static std::string cached;
+  cached = base::UTF16ToUTF8(view->shell->web_contents()->GetTitle());
+  return cached.c_str();
+}
+
+int BlinkBridgeIsLoading(BlinkBridgeView* view) {
+  if (!view || !view->shell || !view->shell->web_contents()) {
+    return 0;
+  }
+  return view->shell->web_contents()->IsLoading() ? 1 : 0;
+}
+
+int BlinkBridgeCanGoBack(BlinkBridgeView* view) {
+  if (!view || !view->shell || !view->shell->web_contents()) {
+    return 0;
+  }
+  return view->shell->web_contents()->GetController().CanGoBack() ? 1 : 0;
+}
+
+int BlinkBridgeCanGoForward(BlinkBridgeView* view) {
+  if (!view || !view->shell || !view->shell->web_contents()) {
+    return 0;
+  }
+  return view->shell->web_contents()->GetController().CanGoForward() ? 1 : 0;
+}
+
+void BlinkBridgeSetUserAgent(BlinkBridgeView* view, const char* ua) {
+  if (!view || !view->shell || !view->shell->web_contents() || !ua) {
+    return;
+  }
+  blink::UserAgentOverride override_ua;
+  override_ua.ua_string_override = ua;
+  view->shell->web_contents()->SetUserAgentOverride(override_ua, true);
+}
+
+void BlinkBridgeSetEventCallback(BlinkBridgeView* view,
+                                 BlinkBridgeCallback cb,
+                                 void* ctx) {
+  if (!view) {
+    return;
+  }
+  view->event_cb = cb;
+  view->event_ctx = ctx;
+}
+
+void BlinkBridgeDestroyView(BlinkBridgeView* view) {
+  if (!view) {
+    return;
+  }
+  view->observer.reset();
+  if (view->shell) {
+    view->shell->Close();
+  }
+  view->shell = nullptr;
+  view->native_view = nil;
+  delete view;
+}
+
+const char* BlinkBridgeLastError(void) {
+  return g_last_error.c_str();
+}
+
+}  // extern "C"

--- a/chromium-blink/build_args.gn
+++ b/chromium-blink/build_args.gn
@@ -1,0 +1,46 @@
+# Blink embed build args — Blinker Fluid configuration (Chromium 149 base
+# 31dce68b925c2b8efc93df832a86a7c0d03e3fa2) + is_component_build for the
+# single-dylib content_shell_framework that OpenMinis dlopens at runtime.
+
+target_os = "ios"
+target_cpu = "arm64"
+target_environment = "device"
+use_blink = true
+
+is_debug = false
+# NOTE: Chromium upstream asserts "Can't use component build on iOS"
+# (build/config/BUILDCONFIG.gn). Blinker Fluid does NOT set is_component_build —
+# ios_framework_bundle("content_shell_framework") still produces a dynamic
+# framework (263MB dylib) in a plain static build, which is exactly what the
+# OpenMinis dlopen bridge needs.
+symbol_level = 0
+treat_warnings_as_errors = false
+
+ios_enable_code_signing = false
+ios_deployment_target = "14.0"
+
+# iOS-15 port: V8 sandbox reserves ~1TB VA; iOS can't grant it. Disabling
+# drops the reservation to the 4GB pointer-compression cage.
+v8_enable_sandbox = false
+v8_enable_pointer_compression = true
+v8_enable_drumbrake = true
+
+# cppgc caged heap tries to reserve 2x4GB VA and aborts on 4GB-VA devices.
+cppgc_enable_caged_heap = false
+
+# Proprietary codecs (H.264/AAC) → VideoToolbox hardware decode.
+proprietary_codecs = true
+ffmpeg_branding = "Chrome"
+
+# DCHECKs abort on debug invariants in the single-process renderer — off for
+# a shipping build.
+dcheck_always_on = false
+
+# Keep output size/disk footprint small (runner has limited disk).
+enable_dsyms = false
+
+# JITless is forced at runtime via --js-flags=--jitless (BlinkBridgeInitialize),
+# keeping this build compatible with both modes.
+
+# Rust/C++ toolchain reuse to cut build time.
+use_remoteexec = false

--- a/chromium-blink/embed_into_app.sh
+++ b/chromium-blink/embed_into_app.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# embed_into_app.sh — copy the Blink engine (the built content_shell.app) into
+# a built Minis.app bundle so the dlopen bridge + resource resolution work.
+#
+# The built content_shell.app already contains the correct assembly of:
+#   Frameworks/content_shell_framework.framework  (the 263MB engine dylib)
+#   icudtl.dat, *.pak, *.ttf, net/ (SSL certs), locales/
+# all resolved by Blink from the MAIN bundle — so we mirror that layout into
+# Minis.app (resources at bundle root, framework under Frameworks/).
+#
+# Usage: ./embed_into_app.sh <minis_app_bundle> <content_shell_app>
+set -euo pipefail
+
+APP="${1:?Minis.app bundle required}"
+CS="${2:?content_shell.app bundle required}"
+
+[ -d "$CS" ] || { echo "!! content_shell.app not found: $CS"; exit 1; }
+echo "==> embedding Blink engine (content_shell.app) into $APP"
+
+# 1. Frameworks (all of them — content_shell_framework may weakly link others).
+mkdir -p "$APP/Frameworks"
+for fw in "$CS"/Frameworks/*; do
+  [ -e "$fw" ] && cp -R "$fw" "$APP/Frameworks/"
+done
+
+# 2. Resources at bundle root (mirroring content_shell.app's own layout).
+for item in "$CS"/*; do
+  name=$(basename "$item")
+  case "$name" in
+    content_shell|Info.plist|PkgInfo|Assets.car|LaunchScreen*) continue ;;
+    *.png) continue ;;  # content_shell's own icons
+    _CodeSignature|embedded.mobileprovision) continue ;;
+  esac
+  cp -R "$item" "$APP/"
+done
+
+echo "==> embedding complete:"
+du -sh "$APP/Frameworks/content_shell_framework.framework"
+ls "$APP" | grep -E "icudtl|\.pak|\.ttf|^net$" || true

--- a/chromium-blink/fetch_and_patch.sh
+++ b/chromium-blink/fetch_and_patch.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# fetch_and_patch.sh — fetch Chromium @ Blinker Fluid base commit, overlay the
+# Blinker Fluid patch set, apply the OpenMinis embed guards, and hook the
+# blink_bridge into content/shell/BUILD.gn.
+#
+# Usage: ./fetch_and_patch.sh <work_dir> <blinker_fluid_dir>
+#   work_dir         - where chromium/ will be created (needs ~80GB free)
+#   blinker_fluid_dir- checkout of https://github.com/Ssabal/blinker-fluid
+set -euo pipefail
+
+WORK="${1:?work_dir required}"
+BF="${2:?blinker_fluid_dir required}"
+
+CHROMIUM_BASE="31dce68b925c2b8efc93df832a86a7c0d03e3fa2"
+BRIDGE_SRC="$(cd "$(dirname "$0")/.." && pwd)/chromium-blink"
+
+echo "==> work: $WORK"
+mkdir -p "$WORK"
+cd "$WORK"
+
+if [ ! -d depot_tools ]; then
+  echo "==> cloning depot_tools"
+  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+fi
+export PATH="$WORK/depot_tools:$PATH"
+"$WORK/depot_tools/update_depot_tools" >/dev/null 2>&1 || true
+# Make depot_tools available to later workflow steps.
+if [ -n "${GITHUB_PATH:-}" ]; then
+  echo "$WORK/depot_tools" >> "$GITHUB_PATH"
+fi
+
+if [ ! -d chromium/src/.git ]; then
+  mkdir -p chromium
+  cat > chromium/.gclient <<EOF
+solutions = [
+  {
+    "name": "src",
+    "url": "https://chromium.googlesource.com/chromium/src.git@${CHROMIUM_BASE}",
+    "managed": False,
+    "custom_deps": {},
+    "custom_vars": {},
+  },
+]
+target_os = ["ios"]
+target_os_only = True
+EOF
+  echo "==> gclient sync (20-40 min, shallow)"
+  cd chromium
+  gclient sync --no-history --nohooks -j8 --shallow
+  cd ..
+fi
+
+cd chromium/src
+echo "==> verifying base commit"
+ACTUAL=$(git rev-parse HEAD)
+echo "    HEAD=$ACTUAL (expected ${CHROMIUM_BASE})"
+
+echo "==> gclient runhooks"
+gclient runhooks
+
+echo "==> overlaying Blinker Fluid patch set"
+cp -R "$BF/src/." ./
+
+echo "==> copying blink_bridge into content/shell/bridge/"
+mkdir -p content/shell/bridge
+cp "$BRIDGE_SRC/bridge/blink_bridge.h" content/shell/bridge/
+cp "$BRIDGE_SRC/bridge/blink_bridge.mm" content/shell/bridge/
+
+echo "==> applying embed guards (python, string-exact)"
+python3 - <<'PYEOF'
+import io, sys
+
+def patch(path, old, new, count=1):
+    with io.open(path, encoding="utf-8") as f:
+        text = f.read()
+    if old not in text:
+        print(f"!! PATCH ANCHOR MISSING: {path}\n   looking for: {old[:80]!r}")
+        sys.exit(1)
+    text = text.replace(old, new, count)
+    with io.open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    print(f"ok: {path}")
+
+# 1. ShellBrowserMainParts: skip auto window/tab creation in embed mode.
+patch(
+    "content/shell/browser/shell_browser_main_parts.cc",
+    """void ShellBrowserMainParts::InitializeMessageLoopContext() {
+#if BUILDFLAG(IS_IOS)
+  // Restore the tabs from last session if there are any (crash-guarded). The
+""",
+    """void ShellBrowserMainParts::InitializeMessageLoopContext() {
+#if BUILDFLAG(IS_IOS)
+  // Blink embed mode (host app such as OpenMinis drives shell creation via the
+  // blink_bridge C API): never auto-create windows or restore tabs here.
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch("blink-embed")) {
+    return;
+  }
+  // Restore the tabs from last session if there are any (crash-guarded). The
+""",
+)
+
+# 2. content/shell/BUILD.gn: add blink_bridge to the framework's deps.
+patch(
+    "content/shell/BUILD.gn",
+    """      ":content_shell_app",
+      ":content_shell_lib",
+""",
+    """      ":content_shell_app",
+      ":content_shell_lib",
+      ":blink_bridge",
+""",
+)
+
+# 3. content/shell/BUILD.gn: append the blink_bridge source_set.
+with io.open("content/shell/BUILD.gn", encoding="utf-8") as f:
+    text = f.read()
+text += """
+# OpenMinis embed bridge: C API exposing Blink shells to a host app.
+source_set("blink_bridge") {
+  testonly = true
+  sources = [
+    "bridge/blink_bridge.h",
+    "bridge/blink_bridge.mm",
+  ]
+  deps = [
+    ":content_shell_lib",
+    "//base",
+    "//content/public/browser",
+    "//net",
+    "//third_party/blink/public/common",
+    "//ui/gfx",
+    "//url",
+  ]
+}
+"""
+with io.open("content/shell/BUILD.gn", "w", encoding="utf-8") as f:
+    f.write(text)
+print("ok: content/shell/BUILD.gn (appended blink_bridge source_set)")
+
+print("ALL PATCHES APPLIED")
+PYEOF
+
+echo "==> gn gen"
+mkdir -p out/Release-iphoneos
+cp "$BRIDGE_SRC/build_args.gn" out/Release-iphoneos/args.gn
+
+# ccache: big speedup for CI iterations (Chromium objects cached across runs).
+if command -v ccache >/dev/null 2>&1; then
+  echo 'cc_wrapper = "ccache"' >> out/Release-iphoneos/args.gn
+  export CCACHE_DIR="${CCACHE_DIR:-$HOME/.cache/ccache}"
+  mkdir -p "$CCACHE_DIR"
+  ccache -M 6G >/dev/null 2>&1 || true
+  echo "==> ccache enabled (dir=$CCACHE_DIR)"
+else
+  echo "==> ccache not found — building without it"
+fi
+
+gn gen out/Release-iphoneos
+
+echo "==> done. Build with: autoninja -C out/Release-iphoneos content_shell"

--- a/docs/blink-engine/README.md
+++ b/docs/blink-engine/README.md
@@ -1,0 +1,105 @@
+# OpenMinis Blink Engine (iOS 16 真实浏览器引擎)
+
+在 OpenMinis 中嵌入真实 Chromium Blink+V8 渲染引擎，替换/补充 WKWebView，让 iOS 16.2 越狱设备（A12Z / TrollStore）上的现代网站正常渲染。
+
+## 背景
+
+- 设备：iPad Pro 2020 (A12Z, arm64e)，iOS 16.2，已越狱，TrollStore 侧载
+- 问题：WKWebView 引擎随系统锁死（iOS 16.2 的 WebKit 太老），现代网站白屏、按钮无响应
+- BrowserEngineKit 需要 iOS 17.4+，不可用
+- 参考实现：**Blinker Fluid**（https://github.com/Ssabal/blinker-fluid）已成功把 Chromium Blink+V8 移植到 iOS 14–16 越狱设备，其产物为 `content_shell.app` + `content_shell_framework.framework`（263MB 单一 dylib，无签名，TrollStore 安装时签名）
+
+## 方案优先级
+
+| 级别 | 方案 | 状态 |
+|------|------|------|
+| P0 | 嵌入 Chromium Blink+V8，替换 WKWebView 渲染，agent 自动化接口不变 | 本分支实现（CI 构建） |
+| P1 | 渲染失败自动降级服务器端渲染取内容（r.jina.ai + 原始 HTML + Wayback，curl 防 TLS 指纹反爬） | 本分支实现（SSR 引擎） |
+| P2 | "用系统默认浏览器打开"选项 | 本分支实现（open_in_browser） |
+
+## 架构
+
+```
+BrowserSheetView / BrowserTabPool
+        │
+        ▼
+BrowserUseManager  (agent 动作执行器，现有 2640 行逻辑不动)
+        │  engineKind: .webkit | .blink | .ssr
+        ├── .webkit ──► WKWebView（现有路径，行为 100% 不变）
+        ├── .blink  ──► BrowserEngineCoordinator ──► BlinkTabSession ──► BlinkEngineBridge
+        │                                                    (dlopen + dlsym) │
+        │                                                                    ▼
+        │                                          content_shell_framework.framework
+        │                                          （Chromium 149 + Blinker Fluid 补丁 + blink_bridge C API）
+        └── .ssr    ──► BrowserEngineCoordinator ──► SSRManager
+                                           (r.jina.ai 经 iSH curl / 原始 HTML / Wayback)
+```
+
+### 为什么用 dlopen 而不是静态链接
+
+- `content_shell_framework.framework` 是单一 263MB dylib，由 CI 构建（macOS 上 xcodebuild 无法编译 Chromium）
+- OpenMinis 主工程**零链接改动**：BlinkEngineBridge 在运行时 `dlopen` + `dlsym` 取 C API
+- 同一个 OpenMinis IPA：默认 WebKit 路径照常工作；TrollStore 构建（嵌入 framework）自动启用 Blink
+- 若 Blink 初始化失败 → 自动回退 WebKit（引擎选择器 + 状态提示）
+
+### C API（blink_bridge，编译进 content_shell_framework）
+
+```
+BlinkBridgeInitialize(bundle_path, tmp_path)   // 一次性：CommandLine/ICU/资源/浏览器主循环
+BlinkBridgeCreateView(x,y,w,h)                 // Shell::CreateNewWindow + GetContentView()
+BlinkBridgeLoadURL / GoBack / GoForward / Reload / Stop
+BlinkBridgeEvaluateJS(js, cb, ctx)             // ExecuteJavaScriptForTests (绕过 CanExecuteJavaScript CHECK)
+BlinkBridgeCaptureSnapshot(cb, ctx)            // UIView drawViewHierarchyInRect → PNG base64
+BlinkBridgeGetURL / GetTitle / IsLoading / CanGoBack / CanGoForward
+BlinkBridgeSetUserAgent / SetViewFrame
+BlinkBridgeSetEventCallback(cb, ctx)           // didFinish/didStartProvisional/titleChanged/loadFailed/windowOpenBlocked
+BlinkBridgeDestroyView
+```
+
+关键点（来自 Blinker Fluid 的坑）：
+- `RenderFrameHost::ExecuteJavaScript` 在真实 http/https 页面会 `CHECK(CanExecuteJavaScript())` 崩溃 —— 必须用 `ExecuteJavaScriptForTests`（content_shell 测试客户端已启用）或隔离世界
+- V8 JITless（iOS VA 限制）、v8_enable_sandbox=false、cppgc_enable_caged_heap=false
+- 进程内渲染（单进程），无 WebContent 子进程 —— `--blink-embed` 开关跳过 Blinker 的窗口/UI 创建
+
+### P1 SSR 降级链（SSRManager）
+
+1. **r.jina.ai**（渲染成 markdown）→ 经 OpenMinis 内嵌 iSH 执行 curl（r.jina.ai 按 TLS 指纹拦截 Python urllib，curl 可过；免费层偶发 Cloudflare 验证页则降级）
+2. **原始 HTML**（URLSession 直连，不依赖设备渲染）→ 内置轻量提取器（title/meta/正文段落）
+3. **Wayback 存档**（archive.org/wayback/available → 快照 HTML）
+
+### P2 系统浏览器打开
+
+- `browser_use` 新增动作 `open_in_browser`（agent 可用）
+- 浏览器 UI 工具栏新增"在系统浏览器中打开"按钮
+
+## 构建（GitHub Actions）
+
+`.github/workflows/blink-build.yml` 两个 job：
+
+1. **build-chromium**（macos-15，约 2–3 小时）：
+   - depot_tools → gclient 浅克隆 Chromium @ `31dce68b925c2b8efc93df832a86a7c0d03e3fa2`
+   - 叠加 blinker-fluid/src 补丁 → 应用 `chromium-blink/patches/embed_guard.patch`
+   - 把 `chromium-blink/bridge/` 挂进 `content/shell/BUILD.gn`（`source_set("blink_bridge")` + framework deps）
+   - `gn gen`（build_args.gn：use_blink=true + Blinker Fluid 全部参数 + is_component_build=true）
+   - `autoninja content_shell` → 产出 `content_shell.app` / `content_shell_framework.framework`
+   - 上传 framework + 资源（icudtl.dat / *.pak / net/data / 字体）为 artifact
+
+2. **build-minis**（macos-14，需等待 job 1）：
+   - xcodebuild 无签名构建 Minis（CODE_SIGNING_ALLOWED=NO，TrollStore 兼容）
+   - 下载 framework artifact → `embed_into_app.sh` 拷入 Minis.app/Frameworks 与资源
+   - 打包 `.ipa` + `.tipa` → 上传 artifact
+
+## 安装（TrollStore）
+
+1. Actions → 最新一次 `blink-build` 运行 → artifacts → 下载 `OpenMinis-Blink-TIPA.tipa`
+2. 打开 TrollStore → 安装 .tipa
+3. 首次使用：设置 → 浏览器引擎 选 Blink（或在浏览器工具栏引擎菜单切换）
+4. 若某网站渲染仍异常 → 引擎菜单切 SSR 取内容，或点"系统浏览器打开"
+
+## 风险与已知限制（v1）
+
+- Blink 引擎在 iOS 16.2 + 进程内渲染下仍可能偶发崩溃（Blinker Fluid 本身标注 EXPERIMENTAL）——崩溃自动回退 WebKit/SSR
+- Blink 模式下 cookies API 暂未桥接（get_cookies/set_cookies 返回明确错误，agent 降级）
+- window.open 弹窗在 Blink 模式下被阻止并上报事件（agent 用 new_tab 显式开新标签）
+- JITless 渲染 JS 密集型站点（地图/大型 SPA）较慢
+- iSH curl 依赖内嵌 rootfs 可用；不可用时 SSR 自动走原始 HTML/Wayback

--- a/scripts/package_tipa.sh
+++ b/scripts/package_tipa.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# package_tipa.sh — package a built .app into .ipa and .tipa (TrollStore).
+# Usage: ./package_tipa.sh <app_bundle> <output_dir>
+set -euo pipefail
+
+APP="${1:?app bundle required}"
+OUT="${2:?output dir required}"
+mkdir -p "$OUT" /tmp/payload/Payload
+
+rm -rf /tmp/payload/Payload/*
+cp -R "$APP" /tmp/payload/Payload/
+cd /tmp/payload
+
+NAME="$(basename "$APP" .app)"
+STAMP="$(date +%Y%m%d-%H%M)"
+IPA="$OUT/OpenMinis-Blink-${STAMP}.ipa"
+TIPA="$OUT/OpenMinis-Blink-${STAMP}.tipa"
+
+rm -f "$IPA" "$TIPA"
+zip -q -r "$IPA" Payload/
+cp "$IPA" "$TIPA"
+
+echo "IPA:  $IPA  ($(du -h "$IPA" | cut -f1))"
+echo "TIPA: $TIPA  ($(du -h "$TIPA" | cut -f1))"

--- a/scripts/pbxproj_add_engine_files.py
+++ b/scripts/pbxproj_add_engine_files.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Add the BrowserUse/Engine/*.swift files to Minis.xcodeproj (app target)."""
+import re
+import sys
+
+PBX = "src/ios/Minis.xcodeproj/project.pbxproj"
+
+NEW_FILES = [
+    "BrowserEngineKind.swift",
+    "BlinkEngineBridge.swift",
+    "BlinkTabSession.swift",
+    "SSRManager.swift",
+    "BrowserEngineCoordinator.swift",
+    "OpenInSystemBrowser.swift",
+]
+
+BROWSER_USE_GROUP_ID = "E57000030"  # the BrowserUse PBXGroup
+BROWSER_USE_MARKER = "E57000011 /* BrowserUseActions.swift */,"  # first child of that group
+
+
+def make_id(i: int) -> str:
+    return f"E5B1{1000 + i:020X}"
+
+
+def main() -> int:
+    with open(PBX, "r", encoding="utf-8") as f:
+        text = f.read()
+
+    ref_ids, build_ids = [], []
+    for i, name in enumerate(NEW_FILES):
+        ref_ids.append(make_id(i * 2))
+        build_ids.append(make_id(i * 2 + 1))
+
+    # 1. PBXBuildFile entries (insert after the section's Begin line)
+    begin = "/* Begin PBXBuildFile section */"
+    assert begin in text
+    build_block = "\n".join(
+        f"\t\t{b} /* {n} in Sources */ = {{isa = PBXBuildFile; fileRef = {r} /* {n} */; }};"
+        for b, r, n in zip(build_ids, ref_ids, NEW_FILES)
+    )
+    text = text.replace(begin, begin + "\n" + build_block, 1)
+
+    # 2. PBXFileReference entries
+    begin = "/* Begin PBXFileReference section */"
+    assert begin in text
+    ref_block = "\n".join(
+        f"\t\t{r} /* {n} */ = {{isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = {n}; sourceTree = \"<group>\"; }};"
+        for r, n in zip(ref_ids, NEW_FILES)
+    )
+    text = text.replace(begin, begin + "\n" + ref_block, 1)
+
+    # 3. New "Engine" PBXGroup + child entries in BrowserUse group
+    engine_group_id = "E5B10000000000000000000E"
+    begin = "/* Begin PBXGroup section */"
+    group_block = (
+        f"\t\t{engine_group_id} /* Engine */ = {{\n"
+        "\t\t\tisa = PBXGroup;\n"
+        "\t\t\tchildren = (\n"
+        + "\n".join(f"\t\t\t\t{r} /* {n} */," for r, n in zip(ref_ids, NEW_FILES))
+        + "\n\t\t\t);\n"
+        '\t\t\tpath = Engine;\n'
+        '\t\t\tsourceTree = "<group>";\n'
+        "\t\t};"
+    )
+    text = text.replace(begin, begin + "\n" + group_block, 1)
+
+    # Add Engine group as a child of the BrowserUse group
+    marker = BROWSER_USE_MARKER
+    assert marker in text, "BrowserUse group marker not found"
+    text = text.replace(marker, f"\t\t\t\t{engine_group_id} /* Engine */,\n{marker}", 1)
+
+    # 4. Add build files to the app target's Sources phase (the phase that
+    #    already compiles BrowserUseActions.swift)
+    phase_marker = "\t\tE57000001 /* BrowserUseActions.swift in Sources */,"
+    assert phase_marker in text, "app Sources phase marker not found"
+    add = "\n".join(f"\t\t{b} /* {n} in Sources */," for b, n in zip(build_ids, NEW_FILES))
+    text = text.replace(phase_marker, phase_marker + "\n" + add, 1)
+
+    with open(PBX, "w", encoding="utf-8") as f:
+        f.write(text)
+
+    # Verify
+    ok = all(
+        f"{r} /* {n} */" in text and f"{b} /* {n} in Sources */" in text
+        for r, b, n in zip(ref_ids, build_ids, NEW_FILES)
+    )
+    print("OK" if ok else "VERIFY FAILED")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/ios/Agent/BrowserUse/BrowserSheetView.swift
+++ b/src/ios/Agent/BrowserUse/BrowserSheetView.swift
@@ -9,9 +9,28 @@ struct BrowserSheetView: View {
     @State private var addressText: String = ""
     @State private var showHistory = false
     @State private var isFullscreen = false
+    @State private var toastMessage: String = ""
     @FocusState private var addressFocused: Bool
 
     private var manager: BrowserUseManager? { pool.activeManager }
+
+    /// Engine shown in the toolbar badge (live from the active tab).
+    private var currentEngineKind: BrowserEngineKind {
+        manager?.engineKind ?? BrowserEngineSettings.shared.effectiveKind
+    }
+
+    /// Switch the pool's engine (persisted; current tab rebuilt at same URL).
+    private func switchEngine(to kind: BrowserEngineKind) {
+        if kind == .blink && !BlinkEngineBridge.isFrameworkPresent() {
+            toastMessage = "Blink 引擎不可用：当前构建未嵌入 content_shell_framework"
+            return
+        }
+        let result = pool.switchEngine(to: kind)
+        toastMessage = result.success ? "" : result.text
+        if let activeURL = manager?.currentURL, !activeURL.isEmpty {
+            addressText = activeURL
+        }
+    }
 
     var body: some View {
         NavigationStack {
@@ -41,7 +60,7 @@ struct BrowserSheetView: View {
                             }
 
                         if manager?.isLoading ?? false {
-                            Button { manager?.webView.stopLoading() } label: {
+                            Button { manager?.stopLoading() } label: {
                                 Image(systemName: "xmark")
                                     .font(.system(size: 12, weight: .medium))
                                     .foregroundStyle(.secondary)
@@ -72,6 +91,24 @@ struct BrowserSheetView: View {
                     if isAgentBusy {
                         AgentBrowsingOverlay(onTakeover: onTakeover)
                             .transition(.opacity)
+                    }
+
+                    // Engine / action toast
+                    if !toastMessage.isEmpty {
+                        Text(toastMessage)
+                            .font(.footnote)
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 8)
+                            .background(Capsule().fill(Color.black.opacity(0.75)))
+                            .padding(.bottom, 24)
+                            .frame(maxHeight: .infinity, alignment: .bottom)
+                            .allowsHitTesting(false)
+                            .transition(.opacity)
+                            .task(id: toastMessage) {
+                                try? await Task.sleep(nanoseconds: 3_000_000_000)
+                                withAnimation { toastMessage = "" }
+                            }
                     }
 
                     // Fullscreen exit button
@@ -184,7 +221,47 @@ struct BrowserSheetView: View {
                     }
                 }
                 ToolbarItem(placement: .topBarTrailing) {
-                    Button("Done") { dismiss() }
+                    HStack(spacing: 14) {
+                        // P2: open in system default browser
+                        Button {
+                            if let url = manager?.currentURL, !url.isEmpty {
+                                if let err = OpenInSystemBrowser.open(url) {
+                                    toastMessage = err
+                                }
+                            }
+                        } label: {
+                            Image(systemName: "safari")
+                        }
+                        .disabled(isAgentBusy || (manager?.currentURL.isEmpty ?? true))
+
+                        // Engine switcher (WebKit / Blink / SSR)
+                        Menu {
+                            ForEach(BrowserEngineKind.allCases) { kind in
+                                Button {
+                                    switchEngine(to: kind)
+                                } label: {
+                                    if kind == currentEngineKind {
+                                        Label(kind.displayName, systemImage: "checkmark")
+                                    } else {
+                                        Text(kind.displayName)
+                                    }
+                                }
+                            }
+                            Divider()
+                            Text("引擎切换对新建标签页生效；当前标签会在同一 URL 重建")
+                                .font(.caption)
+                        } label: {
+                            Text(currentEngineKind.badge)
+                                .font(.caption2.weight(.bold))
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 3)
+                                .background(Capsule().fill(Color.accentColor.opacity(0.15)))
+                                .foregroundStyle(Color.accentColor)
+                        }
+                        .disabled(isAgentBusy)
+
+                        Button("Done") { dismiss() }
+                    }
                 }
                 ToolbarItemGroup(placement: .keyboard) {
                     Spacer()

--- a/src/ios/Agent/BrowserUse/BrowserTabPool.swift
+++ b/src/ios/Agent/BrowserUse/BrowserTabPool.swift
@@ -466,6 +466,54 @@ final class BrowserTabPool: ObservableObject {
         }
     }
 
+    /// P2: open a URL (or the current tab's URL) in the system default browser.
+    private func openInSystemBrowser(url urlString: String?) -> BrowserActionResult {
+        let target: String
+        if let urlString, !urlString.isEmpty {
+            target = urlString
+        } else if let manager = selectedManager, !manager.currentURL.isEmpty {
+            target = manager.currentURL
+        } else {
+            return .error("open_in_browser: 没有可打开的 URL（请先 navigate 或提供 url 参数）")
+        }
+        if let error = OpenInSystemBrowser.open(target) {
+            return .error(error)
+        }
+        return BrowserActionResult(text: "已在系统默认浏览器中打开 \(target)")
+    }
+
+    /// Switch the browser engine for new tabs. Existing tabs keep their engine
+    /// until closed; the current tab is re-created on the new engine at the
+    /// same URL so the change is immediately visible.
+    func switchEngine(to kind: BrowserEngineKind) -> BrowserActionResult {
+        guard BlinkEngineBridge.isFrameworkPresent() || kind != .blink else {
+            return .error("set_engine: Blink 引擎不可用（当前构建未嵌入 content_shell_framework；请安装 Blink/TrollStore 版本）")
+        }
+        BrowserEngineSettings.shared.kind = kind
+        let oldURL = selectedManager?.currentURL
+
+        // Re-create the selected tab on the new engine at the same URL.
+        if let tab = tabs.first(where: { $0.id == selectedTabId }), tab.manager.engineKind != kind {
+            let newManager = makeManager()
+            wireManager(newManager)
+            let replacement = Tab(id: tab.id, manager: newManager, inUse: true,
+                                  graceExpiryTask: tab.graceExpiryTask,
+                                  lastActivityDate: Date())
+            if let idx = tabs.firstIndex(where: { $0.id == tab.id }) {
+                tabs[idx] = replacement
+            }
+            if let oldURL, !oldURL.isEmpty {
+                newManager.loadURL(oldURL)
+            }
+            return BrowserActionResult(
+                text: "已切换到 \(kind.displayName) 引擎（新标签页生效；当前标签已在同一 URL 重建）",
+                pageURL: oldURL.isEmpty ? nil : oldURL
+            )
+        }
+
+        return BrowserActionResult(text: "已设置浏览器引擎为 \(kind.displayName)（新标签页生效）")
+    }
+
     /// Create a new tab using a pre-built WKWebViewConfiguration (for window.open / OAuth popups).
     /// Returns the new tab's WKWebView so the opener retains a window.opener reference.
     /// WebKit will automatically load the navigation into the returned WKWebView.
@@ -731,6 +779,13 @@ final class BrowserTabPool: ObservableObject {
             return closeTab(id: tabId)
         case .listTabs:
             return listTabs()
+        case .openInBrowser:
+            return openInSystemBrowser(url: input.url)
+        case .setEngine:
+            guard let kind = input.engine else {
+                return .error("set_engine: 需要 engine 参数（webkit / blink / ssr）")
+            }
+            return switchEngine(to: kind)
         default:
             break
         }

--- a/src/ios/Agent/BrowserUse/BrowserUseActions.swift
+++ b/src/ios/Agent/BrowserUse/BrowserUseActions.swift
@@ -25,6 +25,10 @@ enum BrowserAction: String, CaseIterable {
     case setCookies = "set_cookies"
     case scrollAndCollect = "scroll_and_collect"
     case waitForDomStable = "wait_for_dom_stable"
+    /// P2: open the current page (or `url`) in the system default browser.
+    case openInBrowser = "open_in_browser"
+    /// Switch the browser engine (webkit / blink / ssr) — applies to new tabs.
+    case setEngine = "set_engine"
 }
 
 // MARK: - Browser Action Input
@@ -62,6 +66,8 @@ struct BrowserActionInput {
     /// keys: name, value (required), and optional domain, path, secure,
     /// http_only, expires (Unix seconds).
     var cookies: [[String: Any]]? = nil
+    /// Engine to switch to (set_engine): "webkit" | "blink" | "ssr".
+    var engine: BrowserEngineKind? = nil
 
     enum ScrollDirection: String {
         case up, down
@@ -106,7 +112,8 @@ struct BrowserActionInput {
             viewportHeight: dict["viewport_height"] as? Int,
             viewportReset: dict["reset"] as? Bool,
             fullPage: dict["full_page"] as? Bool,
-            cookies: Self.parseCookies(dict["cookies"])
+            cookies: Self.parseCookies(dict["cookies"]),
+            engine: (dict["engine"] as? String).flatMap(BrowserEngineKind.init)
         )
     }
 

--- a/src/ios/Agent/BrowserUse/BrowserUseManager.swift
+++ b/src/ios/Agent/BrowserUse/BrowserUseManager.swift
@@ -28,6 +28,27 @@ final class BrowserUseManager: NSObject, ObservableObject {
     // MARK: - Internal
 
     private(set) var webView: WKWebView
+
+    // MARK: - Engine (Blink / SSR)
+
+    /// Active engine for this tab: `.webkit` (default, unchanged WKWebView
+    /// path), `.blink` (embedded Chromium Blink+V8) or `.ssr` (server-side
+    /// rendered content fetch). Decided at init from `BrowserEngineSettings`;
+    /// `.blink` silently downgrades to `.webkit` when the Blink framework
+    /// isn't bundled or fails to initialize.
+    let engineKind: BrowserEngineKind
+    private let engineCoordinator: BrowserEngineCoordinator?
+
+    /// The UIView to embed in the browser sheet: the Blink render surface,
+    /// the SSR placeholder, or this manager's WKWebView for `.webkit`.
+    var renderView: UIView {
+        engineCoordinator?.renderView ?? webView
+    }
+
+    /// True when agent automation must go through the engine coordinator
+    /// instead of the WKWebView (blink renders + evaluates JS there; ssr
+    /// fetches content headlessly).
+    var usesEnginePath: Bool { engineKind != .webkit }
     private var navigationContinuation: CheckedContinuation<Void, Error>?
     @Published private(set) var currentProfile: UserAgentProfile = .mobileSafari
 
@@ -82,12 +103,25 @@ final class BrowserUseManager: NSObject, ObservableObject {
         self.currentProfile = profile
         let vp = Self.resolveViewport(profile: profile, width: viewportWidth, height: viewportHeight)
         self.currentViewport = vp
+        let requested = BrowserEngineSettings.shared.effectiveKind
+        let coord = requested == .webkit
+            ? nil
+            : BrowserEngineCoordinator(
+                kind: requested,
+                frame: CGRect(x: 0, y: 0, width: vp.width, height: vp.height),
+                userAgent: Self.resolveUA(profile: profile, customString: customString),
+                desktop: profile == .desktopSafari,
+                viewportSize: vp)
+        // `coord?.kind` reflects a Blink→WebKit downgrade; keep engineKind in sync.
+        self.engineKind = coord?.kind ?? .webkit
+        self.engineCoordinator = coord
         self.webView = Self.makeWebView(profile: profile, customString: customString,
                                         viewportWidth: vp.width, viewportHeight: vp.height)
         super.init()
         webView.navigationDelegate = self
         webView.uiDelegate = self
         registerPrintHandler(on: webView)
+        wireEngineStateSync()
     }
 
     /// Init with a pre-built configuration (used for window.open popups that share the opener's session).
@@ -96,6 +130,17 @@ final class BrowserUseManager: NSObject, ObservableObject {
         self.currentProfile = profile
         let vp = Self.resolveViewport(profile: profile, width: viewportWidth, height: viewportHeight)
         self.currentViewport = vp
+        let requested = BrowserEngineSettings.shared.effectiveKind
+        let coord = requested == .webkit
+            ? nil
+            : BrowserEngineCoordinator(
+                kind: requested,
+                frame: CGRect(x: 0, y: 0, width: vp.width, height: vp.height),
+                userAgent: Self.resolveUA(profile: profile, customString: customString),
+                desktop: profile == .desktopSafari,
+                viewportSize: vp)
+        self.engineKind = coord?.kind ?? .webkit
+        self.engineCoordinator = coord
         let wv = WKWebView(frame: CGRect(x: 0, y: 0, width: vp.width, height: vp.height), configuration: configuration)
         wv.customUserAgent = Self.resolveUA(profile: profile, customString: customString)
         wv.allowsBackForwardNavigationGestures = true
@@ -104,6 +149,40 @@ final class BrowserUseManager: NSObject, ObservableObject {
         webView.navigationDelegate = self
         webView.uiDelegate = self
         registerPrintHandler(on: webView)
+        wireEngineStateSync()
+    }
+
+    /// Keep the manager's @Published state in sync with Blink/SSR engine events.
+    private func wireEngineStateSync() {
+        engineCoordinator?.onURLChange = { [weak self] url in
+            self?.currentURL = url
+        }
+        engineCoordinator?.onTitleChange = { [weak self] title in
+            self?.pageTitle = title
+        }
+        engineCoordinator?.onLoadingChange = { [weak self] loading in
+            self?.isLoading = loading
+        }
+        engineCoordinator?.onBackForwardChange = { [weak self] back, forward in
+            self?.canGoBack = back
+            self?.canGoForward = forward
+        }
+        engineCoordinator?.onLoadFailed = { [weak self] url, message in
+            guard let self, let url else { return }
+            self.lastRequestedURL = URL(string: url)
+            self.loadError = WebLoadError(
+                error: NSError(domain: NSURLErrorDomain,
+                               code: NSURLErrorCannotConnectToHost,
+                               userInfo: [NSURLErrorFailingURLErrorKey: URL(string: url) as Any]),
+                failedURL: URL(string: url))
+            if let message {
+                logger.error("Engine load failed: \(message)")
+            }
+        }
+        engineCoordinator?.onWindowOpenBlocked = { [weak self] url in
+            logger.info("Blink blocked window.open: \(url ?? "?")")
+            _ = self // manager referenced only to keep closure semantics clear
+        }
     }
 
     private static func resolveViewport(profile: UserAgentProfile,
@@ -223,6 +302,10 @@ final class BrowserUseManager: NSObject, ObservableObject {
 
     /// Present the iOS system print dialog for the current page contents.
     private func presentPrintDialog() {
+        guard engineKind == .webkit else {
+            logger.info("打印仅支持 WebKit 引擎（当前 \(engineKind.displayName)）")
+            return
+        }
         let printController = UIPrintInteractionController.shared
         let printInfo = UIPrintInfo.printInfo()
         printInfo.outputType = .general
@@ -297,6 +380,10 @@ final class BrowserUseManager: NSObject, ObservableObject {
             return await setCookies(input.cookies)
         case .waitForDomStable:
             return try await waitForDomStable(timeout: input.timeout)
+        case .openInBrowser, .setEngine:
+            // Handled at the pool level (needs pool/URL context) — should never
+            // reach the per-tab manager.
+            return .error("\(input.action.rawValue) 由浏览器池处理，不应到达标签页管理器")
         }
 
         let actionMs = Int((CFAbsoluteTimeGetCurrent() - mgrStart) * 1000)
@@ -320,7 +407,7 @@ final class BrowserUseManager: NSObject, ObservableObject {
     /// The DOM summary IS sent to the model (appended to text); the snapshot is NOT
     /// (only imageFilePath is set, no base64Image).
     private func waitForDomSettleAndSnapshot(result: BrowserActionResult) async -> BrowserActionResult {
-        let prevURL = webView.url
+        let prevURL = usesEnginePath ? URL(string: currentURL) : webView.url
         let settleStart = CFAbsoluteTimeGetCurrent()
         // 1. Install MutationObserver and collect a DOM change summary
         let domSummary = await collectDomChangeSummary(timeout: 5.0)
@@ -328,11 +415,22 @@ final class BrowserUseManager: NSObject, ObservableObject {
         logger.info("[SettleTiming] dom_summary elapsed=\(domMs)ms")
 
         // 2. Take snapshot for UI preview (DOM is now stable, better screenshot)
+        let snapStart = CFAbsoluteTimeGetCurrent()
+        var snapshotPath: String? = nil
+        if usesEnginePath {
+            // Engine path: capture the Blink view / SSR placeholder directly.
+            let snapImage = (try? await engineCoordinator?.takeScreenshot()) ?? nil
+            if let image = snapImage, let jpegData = image.jpegData(compressionQuality: 0.7) {
+                lastScreenshot = image
+                let filename = "snapshot_\(Int(Date().timeIntervalSince1970 * 1000)).jpg"
+                let fileURL = Self.screenshotsDir.appendingPathComponent(filename)
+                try? jpegData.write(to: fileURL)
+                snapshotPath = fileURL.path
+            }
+        } else {
         //    Match the frame-resize approach in `screenshot()` so custom
         //    viewports render at their intended size even when the browser
         //    sheet is stretching the WKWebView to fill a different container.
-        let snapStart = CFAbsoluteTimeGetCurrent()
-        var snapshotPath: String? = nil
         let targetSize = CGSize(width: CGFloat(currentViewport.width),
                                 height: CGFloat(currentViewport.height))
         let savedFrame = webView.frame
@@ -365,6 +463,7 @@ final class BrowserUseManager: NSObject, ObservableObject {
             // (T-ios-browser-sheet-viewport-pollution)
             restoreViewportFrame()
         }
+        }
 
         let snapMs = Int((CFAbsoluteTimeGetCurrent() - snapStart) * 1000)
         logger.info("[SettleTiming] snapshot elapsed=\(snapMs)ms")
@@ -376,7 +475,7 @@ final class BrowserUseManager: NSObject, ObservableObject {
         }
 
         // 4. Detect URL change (ignore hash-only changes)
-        let newURL = webView.url
+        let newURL = usesEnginePath ? URL(string: currentURL) : webView.url
         if let prev = prevURL, let cur = newURL {
             let prevNoHash = prev.absoluteString.components(separatedBy: "#").first ?? prev.absoluteString
             let curNoHash = cur.absoluteString.components(separatedBy: "#").first ?? cur.absoluteString
@@ -569,6 +668,11 @@ final class BrowserUseManager: NSObject, ObservableObject {
     /// suspended — but it IS throttled, which stretches Task timers). A GCD timer
     /// on a background queue is wall-clock and keeps firing on time regardless.
     private func evaluateJavaScriptBounded(_ js: String, timeout: TimeInterval = 10) async throws -> Any? {
+        // Engine path (Blink/SSR): route through the engine coordinator.
+        if usesEnginePath {
+            guard let engineCoordinator else { return nil }
+            return try await engineCoordinator.evaluateJavaScript(js, timeout: timeout)
+        }
         // Bridge WKWebView's completion-handler API to a continuation, and race
         // it against a wall-clock GCD timer. The first to resume the continuation
         // wins; the loser's resume is dropped via the `done` flag (a continuation
@@ -682,6 +786,36 @@ final class BrowserUseManager: NSObject, ObservableObject {
             return .error("Cannot navigate to \(scheme):// URLs. Only http://, https://, and minis:// are supported.")
         }
 
+        // Engine path (Blink / SSR): the engine coordinator owns loading.
+        if usesEnginePath {
+            if scheme == "minis" {
+                return .error("minis:// 页面仅支持 WebKit 引擎，请在浏览器引擎设置中切换到 WebKit")
+            }
+            logger.info("[NavTiming] engine_load_start url=\(url.absoluteString.prefix(100)) engine=\(engineKind.rawValue)")
+            lastRequestedURL = url          // [T-ios-webview-error-ui]
+            loadError = nil
+            isLoading = true
+            do {
+                let meta = try await engineCoordinator?.navigate(to: url.absoluteString) ?? "加载完成"
+                isLoading = false
+                let info = engineCoordinator?.currentPageInfo()
+                currentURL = info?.url ?? url.absoluteString
+                pageTitle = info?.title ?? ""
+                logger.info("[NavTiming] engine_load_done url=\(url.absoluteString.prefix(100))")
+                return BrowserActionResult(text: meta, pageURL: info?.url ?? url.absoluteString)
+            } catch {
+                isLoading = false
+                loadError = WebLoadError(
+                    error: NSError(domain: NSURLErrorDomain,
+                                   code: NSURLErrorCannotConnectToHost,
+                                   userInfo: [NSURLErrorFailingURLErrorKey: url]),
+                    failedURL: url)
+                let msg = error.localizedDescription
+                logger.error("[NavTiming] engine_load_failed url=\(url.absoluteString.prefix(80)) err=\(msg)")
+                return .error("加载失败 (\(engineKind.displayName)): \(msg)")
+            }
+        }
+
         logger.info("[NavTiming] load_start url=\(url.absoluteString.prefix(100))")
 
         // Record the visit so this domain's cookie backup stays alive (keeps
@@ -745,6 +879,36 @@ final class BrowserUseManager: NSObject, ObservableObject {
     private static let fullPageMaxHeight: CGFloat = 32_768
 
     private func screenshot(fullPage: Bool = false) async throws -> BrowserActionResult {
+        // Engine path (Blink/SSR): snapshot via the engine coordinator.
+        if usesEnginePath {
+            guard let engineCoordinator else { return .error("引擎未初始化") }
+            let ssStart = CFAbsoluteTimeGetCurrent()
+            do {
+                let image = try await engineCoordinator.takeScreenshot()
+                guard let jpegData = image.jpegData(compressionQuality: 0.8) else {
+                    return .error("Failed to encode screenshot as JPEG")
+                }
+                let filename = "screenshot_\(Int(Date().timeIntervalSince1970 * 1000)).jpg"
+                let fileURL = Self.screenshotsDir.appendingPathComponent(filename)
+                try jpegData.write(to: fileURL)
+                lastScreenshot = image
+                let ms = Int((CFAbsoluteTimeGetCurrent() - ssStart) * 1000)
+                logger.info("[ScreenshotTiming] engine snapshot elapsed=\(ms)ms engine=\(engineKind.rawValue)")
+                let text: String
+                if engineKind == .ssr {
+                    text = "SSR 模式：无实时渲染截图（占位图）。页面内容请查看 navigate/get_text 结果。"
+                } else {
+                    text = "截图 \(Int(image.size.width))x\(Int(image.size.height))（\(jpegData.count) 字节，\(engineKind.badge) 引擎）"
+                }
+                return BrowserActionResult(
+                    text: text,
+                    base64Image: jpegData.base64EncodedString(),
+                    imageFilePath: fileURL.path
+                )
+            } catch {
+                return .error("截图失败 (\(engineKind.displayName)): \(error.localizedDescription)")
+            }
+        }
         let ssStart = CFAbsoluteTimeGetCurrent()
         logger.info("[ScreenshotTiming] enter fullPage=\(fullPage)")
         // If the webView's current bounds don't match the intended viewport
@@ -1054,12 +1218,23 @@ final class BrowserUseManager: NSObject, ObservableObject {
     // MARK: - Get Page Info
 
     private func getPageInfo() async throws -> BrowserActionResult {
+        if engineKind == .ssr {
+            let info = engineCoordinator?.currentPageInfo() ?? ("", "", false, false, false)
+            var lines: [String] = []
+            lines.append("URL: \(info.url.isEmpty ? "(未加载)" : info.url)")
+            lines.append("Title: \(info.title.isEmpty ? "(无标题)" : info.title)")
+            lines.append("Engine: SSR（服务器渲染，无 JS/DOM）")
+            return BrowserActionResult(text: lines.joined(separator: "\n"), pageURL: info.url.isEmpty ? nil : info.url)
+        }
         return try await evaluateAndReturn(BrowserUseJS.getPageInfo())
     }
 
     // MARK: - Get Cookies
 
     private func getCookies(keywords: [String]?, fuzzy: Bool) async -> BrowserActionResult {
+        if usesEnginePath {
+            return .error("cookies API 暂未接入 \(engineKind.displayName) 引擎；请切回 WebKit 引擎或直接在页面中登录")
+        }
         guard let pageURL = webView.url else {
             return .error("No page is currently loaded")
         }
@@ -1189,6 +1364,9 @@ final class BrowserUseManager: NSObject, ObservableObject {
     /// Symmetric with `getCookies`. Each entry needs `name` + `value`; `domain`
     /// defaults to the current page host, `path` to "/".
     private func setCookies(_ cookies: [[String: Any]]?) async -> BrowserActionResult {
+        if usesEnginePath {
+            return .error("cookies API 暂未接入 \(engineKind.displayName) 引擎；请切回 WebKit 引擎或直接在页面中登录")
+        }
         guard let pageURL = webView.url else {
             return .error("set_cookies: no page is loaded (navigate first)")
         }
@@ -1557,6 +1735,44 @@ final class BrowserUseManager: NSObject, ObservableObject {
 
         logger.info("Fetching resource: \(urlString)")
 
+        // Engine path (Blink/SSR): URLSession fetch (engine-independent).
+        if usesEnginePath {
+            guard let url = URL(string: urlString),
+                  let scheme = url.scheme?.lowercased(),
+                  ["http", "https"].contains(scheme) else {
+                return .error("fetch 仅支持 http/https URL（\(engineKind.displayName) 引擎）")
+            }
+            guard let engineCoordinator else { return .error("引擎未初始化") }
+            do {
+                let (data, response) = try await engineCoordinator.fetchData(from: url)
+                let http = response as? HTTPURLResponse
+                let contentType = http?.value(forHTTPHeaderField: "Content-Type") ?? ""
+                let contentDisposition = http?.value(forHTTPHeaderField: "Content-Disposition") ?? ""
+                let status = http?.statusCode ?? 0
+                let filename: String
+                if let cdName = Self.parseContentDispositionFilename(contentDisposition) {
+                    filename = "\(Int(Date().timeIntervalSince1970))_\(cdName)"
+                } else if !url.lastPathComponent.isEmpty, url.lastPathComponent != "/" {
+                    filename = "\(Int(Date().timeIntervalSince1970))_\(url.lastPathComponent)"
+                } else {
+                    filename = "fetch_\(Int(Date().timeIntervalSince1970)).\(Self.extensionForMimeType(contentType))"
+                }
+                var lines: [String] = []
+                lines.append("Fetched \(url.absoluteString)")
+                lines.append("  Status: \(status)")
+                lines.append("  Content-Type: \(contentType)")
+                lines.append("  Size: \(Self.formatBytes(data.count))")
+                lines.append("  Filename: \(filename)")
+                return BrowserActionResult(
+                    text: lines.joined(separator: "\n"),
+                    fetchedFileData: data,
+                    fetchedFileName: filename
+                )
+            } catch {
+                return .error("Fetch failed: \(error.localizedDescription)")
+            }
+        }
+
         let js = """
         (async function() {
             try {
@@ -1699,6 +1915,13 @@ final class BrowserUseManager: NSObject, ObservableObject {
     func setUserAgent(profile: UserAgentProfile?, customString: String? = nil) -> BrowserActionResult {
         let newProfile = profile ?? .mobileSafari
 
+        if usesEnginePath {
+            currentProfile = newProfile
+            let ua = Self.resolveUA(profile: newProfile, customString: customString)
+            engineCoordinator?.setUserAgent(ua)
+            return BrowserActionResult(text: "Switched to \(newProfile.rawValue) (\(currentViewport.width)x\(currentViewport.height)) [\(engineKind.badge)]")
+        }
+
         currentProfile = newProfile
         // Preserve the current viewport across UA switches so a user-set
         // custom viewport survives an agent-driven UA flip.
@@ -1726,6 +1949,12 @@ final class BrowserUseManager: NSObject, ObservableObject {
     /// global or session custom viewport changes.
     func setViewport(width: Int, height: Int,
                      profile: UserAgentProfile, customUA: String?) {
+        if usesEnginePath {
+            currentProfile = profile
+            currentViewport = (width, height)
+            engineCoordinator?.applyViewport(desktop: profile == .desktopSafari, width: width)
+            return
+        }
         currentProfile = profile
         currentViewport = (width, height)
 
@@ -1758,6 +1987,7 @@ final class BrowserUseManager: NSObject, ObservableObject {
     /// (T-ios-browser-sheet-viewport-pollution)
     @MainActor
     func restoreViewportFrame() {
+        guard engineKind == .webkit else { return }  // Blink/SSR 有自己的视口管理
         // [T-ios-webview-phantom-keyboard] This runs when the browser sheet
         // closes / before a screenshot — i.e. the webView is going back
         // offscreen. Release any focused input's remote keyboard here too, so a
@@ -1804,25 +2034,40 @@ final class BrowserUseManager: NSObject, ObservableObject {
     // MARK: - User Navigation
 
     func goBack() {
+        if usesEnginePath { engineCoordinator?.goBack(); return }
         guard webView.canGoBack else { return }
         webView.goBack()
     }
 
     func goForward() {
+        if usesEnginePath { engineCoordinator?.goForward(); return }
         guard webView.canGoForward else { return }
         webView.goForward()
     }
 
     func reload() {
+        if usesEnginePath { engineCoordinator?.reload(); return }
         webView.reload()
     }
 
     func stopLoading() {
+        if usesEnginePath { engineCoordinator?.stopLoading(); return }
         webView.stopLoading()
         isLoading = false
     }
 
     func loadURL(_ urlString: String) {
+        if usesEnginePath {
+            var normalized = urlString
+            if !normalized.contains("://") {
+                normalized = "https://\(normalized)"
+            }
+            isLoading = true
+            Task { @MainActor in
+                _ = try? await engineCoordinator?.navigate(to: normalized)
+            }
+            return
+        }
         var normalized = urlString
         if !normalized.contains("://") {
             normalized = "https://\(normalized)"

--- a/src/ios/Agent/BrowserUse/BrowserWebView.swift
+++ b/src/ios/Agent/BrowserUse/BrowserWebView.swift
@@ -1,15 +1,18 @@
 import SwiftUI
+import UIKit
 import WebKit
 
-/// UIViewRepresentable wrapper that displays a `BrowserUseManager`'s WKWebView.
+/// UIViewRepresentable wrapper that displays a `BrowserUseManager`'s render
+/// surface — the WKWebView for the `.webkit` engine, the Blink render view for
+/// `.blink`, or the SSR placeholder for `.ssr`.
 struct BrowserWebView: UIViewRepresentable {
     let manager: BrowserUseManager
 
-    func makeUIView(context: Context) -> WKWebView {
-        manager.webView
+    func makeUIView(context: Context) -> UIView {
+        manager.renderView
     }
 
-    func updateUIView(_ uiView: WKWebView, context: Context) {
-        // The manager owns the webView — nothing to update here.
+    func updateUIView(_ uiView: UIView, context: Context) {
+        // The manager owns the render view — nothing to update here.
     }
 }

--- a/src/ios/Agent/BrowserUse/Engine/BlinkEngineBridge.swift
+++ b/src/ios/Agent/BrowserUse/Engine/BlinkEngineBridge.swift
@@ -1,0 +1,355 @@
+import Foundation
+import UIKit
+import os.log
+
+private let engineLogger = AppLogger(category: "BlinkBridge")
+
+// MARK: - C API (blink_bridge.h, compiled into content_shell_framework.framework)
+//
+// All functions are called on the main thread. Callbacks fire on the main
+// thread (the C side hops to the main queue before invoking them).
+// Result payloads are JSON strings; see BlinkBridgeEvent parsing below.
+
+// MARK: - Bridge Availability
+
+/// dlopen/dlsym wrapper around the `blink_bridge` C API exported by
+/// `content_shell_framework.framework` (the Chromium Blink engine built by CI).
+///
+/// The framework is embedded ONLY in the Blink/TrollStore build; this wrapper
+/// is safe to call from any build — `isFrameworkPresent()` returns false when
+/// the framework is absent and every other method is a no-op/failure.
+final class BlinkEngineBridge {
+
+    // MARK: Typealiases
+
+    typealias EventCallback = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
+
+    // MARK: Symbols (lazily resolved)
+
+    private struct Symbols {
+        let initialize: @convention(c) (UnsafePointer<CChar>?, UnsafePointer<CChar>?) -> Int32
+        let createView: @convention(c) (Int32, Int32, Int32, Int32) -> UnsafeMutableRawPointer?
+        let setViewFrame: @convention(c) (UnsafeMutableRawPointer?, Int32, Int32, Int32, Int32) -> Void
+        let loadURL: @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
+        let goBack: @convention(c) (UnsafeMutableRawPointer?) -> Void
+        let goForward: @convention(c) (UnsafeMutableRawPointer?) -> Void
+        let reload: @convention(c) (UnsafeMutableRawPointer?) -> Void
+        let stop: @convention(c) (UnsafeMutableRawPointer?) -> Void
+        let evaluateJS: @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?, EventCallback?, UnsafeMutableRawPointer?) -> Void
+        let captureSnapshot: @convention(c) (UnsafeMutableRawPointer?, EventCallback?, UnsafeMutableRawPointer?) -> Void
+        let getURL: @convention(c) (UnsafeMutableRawPointer?) -> UnsafePointer<CChar>?
+        let getTitle: @convention(c) (UnsafeMutableRawPointer?) -> UnsafePointer<CChar>?
+        let isLoading: @convention(c) (UnsafeMutableRawPointer?) -> Int32
+        let canGoBack: @convention(c) (UnsafeMutableRawPointer?) -> Int32
+        let canGoForward: @convention(c) (UnsafeMutableRawPointer?) -> Int32
+        let setUserAgent: @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
+        let setEventCallback: @convention(c) (UnsafeMutableRawPointer?, EventCallback?, UnsafeMutableRawPointer?) -> Void
+        let destroyView: @convention(c) (UnsafeMutableRawPointer?) -> Void
+        let lastError: @convention(c) () -> UnsafePointer<CChar>?
+    }
+
+    // MARK: State
+
+    /// dlopen'd symbols. `nonisolated(unsafe)`: all bridge access is
+    /// main-thread by design (the C API requires it), including deinit paths.
+    nonisolated(unsafe) private static var symbols: Symbols?
+    nonisolated(unsafe) private static var frameworkHandle: UnsafeMutableRawPointer?
+
+    private static let frameworkPath = Bundle.main.bundlePath + "/Frameworks/content_shell_framework.framework/content_shell_framework"
+
+    // MARK: Availability
+
+    /// True when the Blink framework is bundled (Blink/TrollStore build).
+    static func isFrameworkPresent() -> Bool {
+        FileManager.default.fileExists(atPath: frameworkPath)
+    }
+
+    /// Load the framework and resolve every symbol. Returns false on failure
+    /// (framework missing, wrong arch, missing symbol — caller falls back).
+    @discardableResult
+    static func loadIfNeeded() -> Bool {
+        if symbols != nil { return true }
+        guard isFrameworkPresent() else {
+            engineLogger.info("Blink framework not bundled — Blink engine unavailable")
+            return false
+        }
+        guard let handle = dlopen(frameworkPath, RTLD_NOW | RTLD_LOCAL) else {
+            if let err = dlerror() {
+                engineLogger.error("dlopen content_shell_framework failed: \(String(cString: err))")
+            }
+            return false
+        }
+        frameworkHandle = handle
+
+        func sym<T>(_ name: String) -> T? {
+            guard let ptr = dlsym(handle, name) else { return nil }
+            return unsafeBitCast(ptr, to: T.self)
+        }
+
+        guard let s = Symbols(
+            initialize: sym("BlinkBridgeInitialize"),
+            createView: sym("BlinkBridgeCreateView"),
+            setViewFrame: sym("BlinkBridgeSetViewFrame"),
+            loadURL: sym("BlinkBridgeLoadURL"),
+            goBack: sym("BlinkBridgeGoBack"),
+            goForward: sym("BlinkBridgeGoForward"),
+            reload: sym("BlinkBridgeReload"),
+            stop: sym("BlinkBridgeStop"),
+            evaluateJS: sym("BlinkBridgeEvaluateJS"),
+            captureSnapshot: sym("BlinkBridgeCaptureSnapshot"),
+            getURL: sym("BlinkBridgeGetURL"),
+            getTitle: sym("BlinkBridgeGetTitle"),
+            isLoading: sym("BlinkBridgeIsLoading"),
+            canGoBack: sym("BlinkBridgeCanGoBack"),
+            canGoForward: sym("BlinkBridgeCanGoForward"),
+            setUserAgent: sym("BlinkBridgeSetUserAgent"),
+            setEventCallback: sym("BlinkBridgeSetEventCallback"),
+            destroyView: sym("BlinkBridgeDestroyView"),
+            lastError: sym("BlinkBridgeLastError")
+        ) else {
+            engineLogger.error("Blink bridge: missing symbol(s) in content_shell_framework")
+            return false
+        }
+        symbols = s
+        engineLogger.info("Blink bridge loaded: \(self.frameworkPath)")
+        return true
+    }
+
+    // MARK: Init
+
+    /// One-time Chromium browser-process init. Call from the main thread before
+    /// creating any view. Returns true on success.
+    static func initialize() -> Bool {
+        guard loadIfNeeded(), let s = symbols else { return false }
+        let bundle = Bundle.main.bundlePath
+        let tmp = NSTemporaryDirectory()
+        let rc = bundle.withCString { bp in
+            tmp.withCString { tp in
+                s.initialize(bp, tp)
+            }
+        }
+        if rc != 0 {
+            engineLogger.error("BlinkBridgeInitialize failed rc=\(rc) err=\(bridgeLastError())")
+            return false
+        }
+        return true
+    }
+
+    private static func bridgeLastError() -> String {
+        guard let s = symbols, let err = s.lastError() else { return "unknown" }
+        return String(cString: err)
+    }
+
+    // MARK: View lifecycle
+
+    static func createView(width: CGFloat, height: CGFloat) -> UnsafeMutableRawPointer? {
+        guard let s = symbols else { return nil }
+        return s.createView(Int32(width), Int32(height), Int32(width), Int32(height))
+    }
+
+    static func setViewFrame(_ handle: UnsafeMutableRawPointer, x: CGFloat, y: CGFloat, width: CGFloat, height: CGFloat) {
+        guard let s = symbols else { return }
+        s.setViewFrame(handle, Int32(x), Int32(y), Int32(width), Int32(height))
+    }
+
+    static func destroyView(_ handle: UnsafeMutableRawPointer) {
+        guard let s = symbols else { return }
+        s.destroyView(handle)
+    }
+
+    /// Nonisolated destroy for use from `deinit` (main-thread by contract).
+    nonisolated(unsafe) static func destroyViewFromDeinit(_ handle: UnsafeMutableRawPointer) {
+        symbols?.destroyView(handle)
+    }
+
+    // MARK: Navigation
+
+    static func loadURL(_ handle: UnsafeMutableRawPointer, _ url: String) {
+        guard let s = symbols else { return }
+        url.withCString { s.loadURL(handle, $0) }
+    }
+
+    static func goBack(_ handle: UnsafeMutableRawPointer) { symbols?.goBack(handle) }
+    static func goForward(_ handle: UnsafeMutableRawPointer) { symbols?.goForward(handle) }
+    static func reload(_ handle: UnsafeMutableRawPointer) { symbols?.reload(handle) }
+    static func stop(_ handle: UnsafeMutableRawPointer) { symbols?.stop(handle) }
+
+    static func setUserAgent(_ handle: UnsafeMutableRawPointer, _ ua: String) {
+        guard let s = symbols else { return }
+        ua.withCString { s.setUserAgent(handle, $0) }
+    }
+
+    // MARK: State
+
+    static func getURL(_ handle: UnsafeMutableRawPointer) -> String {
+        guard let s = symbols, let p = s.getURL(handle) else { return "" }
+        return String(cString: p)
+    }
+
+    static func getTitle(_ handle: UnsafeMutableRawPointer) -> String {
+        guard let s = symbols, let p = s.getTitle(handle) else { return "" }
+        return String(cString: p)
+    }
+
+    static func isLoading(_ handle: UnsafeMutableRawPointer) -> Bool {
+        guard let s = symbols else { return false }
+        return s.isLoading(handle) != 0
+    }
+
+    static func canGoBack(_ handle: UnsafeMutableRawPointer) -> Bool {
+        guard let s = symbols else { return false }
+        return s.canGoBack(handle) != 0
+    }
+
+    static func canGoForward(_ handle: UnsafeMutableRawPointer) -> Bool {
+        guard let s = symbols else { return false }
+        return s.canGoForward(handle) != 0
+    }
+
+    // MARK: JS evaluation (main world — agent automation)
+
+    /// Evaluate JS in the page's main world. `completion` receives `(result, error)`.
+    /// `result` is the JSON-decoded value when the script returns JSON-serializable
+    /// data, or `nil`. Errors arrive as a JSON string payload from the C side.
+    static func evaluateJavaScript(_ handle: UnsafeMutableRawPointer,
+                                   _ js: String,
+                                   completion: @escaping (Any?, Error?) -> Void) {
+        guard let s = symbols else {
+            completion(nil, BlinkBridgeError.notLoaded)
+            return
+        }
+        let box = CallbackBox { payload in
+            BlinkBridgeResultParser.parseEval(payload, completion: completion)
+        }
+        js.withCString { cstr in
+            s.evaluateJS(handle, cstr, { ctx, payload in
+                guard let ctx else { return }
+                let box = Unmanaged<CallbackBox>.fromOpaque(ctx).takeRetainedValue()
+                box.invoke(payload.map { String(cString: $0) })
+            }, Unmanaged.passRetained(box).toOpaque())
+        }
+    }
+
+    // MARK: Snapshot
+
+    /// Capture the current view as PNG. `completion` receives `(pngData, error)`.
+    static func captureSnapshot(_ handle: UnsafeMutableRawPointer,
+                                completion: @escaping (Data?, Error?) -> Void) {
+        guard let s = symbols else {
+            completion(nil, BlinkBridgeError.notLoaded)
+            return
+        }
+        let box = CallbackBox { payload in
+            guard let payload,
+                  let data = Data(base64Encoded: payload) else {
+                completion(nil, BlinkBridgeError.snapshotFailed)
+                return
+            }
+            completion(data, nil)
+        }
+        s.captureSnapshot(handle, { ctx, payload in
+            guard let ctx else { return }
+            let box = Unmanaged<CallbackBox>.fromOpaque(ctx).takeRetainedValue()
+            box.invoke(payload.map { String(cString: $0) })
+        }, Unmanaged.passRetained(box).toOpaque())
+    }
+
+    // MARK: Events
+
+    /// Event kinds emitted by the engine (values mirror blink_bridge.h).
+    enum BridgeEvent: String {
+        case didStartProvisionalNavigation = "didStartProvisionalNavigation"
+        case didFinishNavigation = "didFinishNavigation"
+        case didFailNavigation = "didFailNavigation"
+        case titleChanged = "titleChanged"
+        case urlChanged = "urlChanged"
+        case loadingStateChanged = "loadingStateChanged"
+        case windowOpenBlocked = "windowOpenBlocked"
+        case renderProcessGone = "renderProcessGone"
+    }
+
+    struct BridgeEventPayload: Sendable {
+        let event: BridgeEvent
+        let url: String?
+        let error: String?
+        let title: String?
+        let loading: Bool?
+    }
+
+    /// Install the event callback for a view. The C side fires it on the main
+    /// thread. Replaces any previous callback.
+    static func setEventCallback(_ handle: UnsafeMutableRawPointer,
+                                 handler: @escaping (BridgeEventPayload) -> Void) {
+        guard let s = symbols else { return }
+        let box = CallbackBox { payload in
+            guard let payload,
+                  let dict = try? JSONSerialization.jsonObject(with: Data(payload.utf8)) as? [String: Any],
+                  let eventRaw = dict["event"] as? String,
+                  let event = BridgeEvent(rawValue: eventRaw) else { return }
+            let parsed = BridgeEventPayload(
+                event: event,
+                url: dict["url"] as? String,
+                error: dict["error"] as? String,
+                title: dict["title"] as? String,
+                loading: (dict["loading"] as? NSNumber)?.boolValue
+            )
+            handler(parsed)
+        }
+        s.setEventCallback(handle, { ctx, payload in
+            guard let ctx else { return }
+            let box = Unmanaged<CallbackBox>.fromOpaque(ctx).takeRetainedValue()
+            box.invoke(payload.map { String(cString: $0) })
+        }, Unmanaged.passRetained(box).toOpaque())
+    }
+}
+
+// MARK: - Support Types
+
+enum BlinkBridgeError: LocalizedError {
+    case notLoaded
+    case initializeFailed
+    case viewCreationFailed
+    case evaluationFailed(String)
+    case snapshotFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .notLoaded: return "Blink 引擎未加载（非 Blink 构建？）"
+        case .initializeFailed: return "Blink 引擎初始化失败"
+        case .viewCreationFailed: return "Blink 引擎创建视图失败"
+        case .evaluationFailed(let msg): return "Blink JS 执行失败: \(msg)"
+        case .snapshotFailed: return "Blink 截图失败"
+        }
+    }
+}
+
+/// Holds a Swift closure across the C callback boundary.
+final class CallbackBox {
+    private let handler: (String?) -> Void
+    init(handler: @escaping (String?) -> Void) { self.handler = handler }
+    func invoke(_ payload: String?) { handler(payload) }
+}
+
+/// Parses BlinkBridgeEvaluateJS result payloads:
+/// `{"ok":true,"value":<json>}` | `{"ok":false,"error":"..."}` | `{"ok":true}` (undefined)
+enum BlinkBridgeResultParser {
+    static func parseEval(_ payload: String?, completion: (Any?, Error?) -> Void) {
+        guard let payload else {
+            completion(nil, nil)
+            return
+        }
+        guard let data = payload.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            // Non-JSON payload: pass through as raw string.
+            completion(payload, nil)
+            return
+        }
+        if let ok = dict["ok"] as? Bool, ok {
+            completion(dict["value"], nil)
+        } else if let err = dict["error"] as? String {
+            completion(nil, BlinkBridgeError.evaluationFailed(err))
+        } else {
+            completion(nil, nil)
+        }
+    }
+}

--- a/src/ios/Agent/BrowserUse/Engine/BlinkTabSession.swift
+++ b/src/ios/Agent/BrowserUse/Engine/BlinkTabSession.swift
@@ -1,0 +1,310 @@
+import Foundation
+import UIKit
+import os.log
+
+private let blinkLog = AppLogger(category: "BlinkTab")
+
+// MARK: - Blink Web View
+
+/// A UIView that hosts the Blink-rendered page for one tab.
+/// Talks to the embedded `content_shell_framework` through `BlinkEngineBridge`.
+@MainActor
+final class BlinkWebView: UIView {
+
+    /// Engine-side handle (`void*` from BlinkBridgeCreateView).
+    private(set) var engineHandle: UnsafeMutableRawPointer?
+
+    // MARK: State mirror (drives BrowserUseManager's published state)
+
+    var currentURL: String = ""
+    var pageTitle: String = ""
+    var isLoading: Bool = false
+    var canGoBack: Bool = false
+    var canGoForward: Bool = false
+
+    /// Fired on engine events (navigation state / title / URL / errors).
+    var onStateChange: ((_ url: String?, _ title: String?, _ loading: Bool?) -> Void)?
+    /// Fired when a page navigation fails (DNS/TLS/timeout).
+    var onLoadFailed: ((_ url: String?, _ error: String?) -> Void)?
+    /// Fired when the engine blocks a window.open / target=_blank popup.
+    var onWindowOpenBlocked: ((_ url: String?) -> Void)?
+    /// Fired when the Blink renderer/browser process died (usually OOM).
+    var onRenderProcessGone: (() -> Void)?
+
+    private var pendingEvalCompletions: [UInt64: (Any?, Error?) -> Void] = [:]
+    private var nextEvalID: UInt64 = 0
+
+    // MARK: Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        clipsToBounds = true
+        backgroundColor = .white
+        createEngineView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        clipsToBounds = true
+        backgroundColor = .white
+        createEngineView()
+    }
+
+    deinit {
+        if let handle = engineHandle {
+            BlinkEngineBridge.destroyViewFromDeinit(handle)
+            engineHandle = nil
+        }
+    }
+
+    private func createEngineView() {
+        guard let handle = BlinkEngineBridge.createView(width: bounds.width, height: bounds.height) else {
+            blinkLog.error("BlinkBridgeCreateView failed")
+            return
+        }
+        engineHandle = handle
+        BlinkEngineBridge.setEventCallback(handle) { [weak self] payload in
+            Task { @MainActor [weak self] in
+                self?.handleBridgeEvent(payload)
+            }
+        }
+        refreshState()
+    }
+
+    // MARK: Layout
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        guard let handle = engineHandle, bounds.width > 0, bounds.height > 0 else { return }
+        BlinkEngineBridge.setViewFrame(handle, x: 0, y: 0, width: bounds.width, height: bounds.height)
+    }
+
+    // MARK: Navigation API
+
+    func loadURL(_ urlString: String) {
+        guard let handle = engineHandle else { return }
+        currentURL = urlString
+        isLoading = true
+        BlinkEngineBridge.loadURL(handle, urlString)
+    }
+
+    func goBack() { guard let h = engineHandle else { return }; BlinkEngineBridge.goBack(h); refreshState() }
+    func goForward() { guard let h = engineHandle else { return }; BlinkEngineBridge.goForward(h); refreshState() }
+    func reload() { guard let h = engineHandle else { return }; BlinkEngineBridge.reload(h) }
+    func stopLoading() { guard let h = engineHandle else { return }; BlinkEngineBridge.stop(h) }
+    func setUserAgent(_ ua: String) { guard let h = engineHandle else { return }; BlinkEngineBridge.setUserAgent(h, ua) }
+
+    // MARK: JS Evaluation
+
+    /// Evaluate JS in the main world with a timeout. `result` is the
+    /// JSON-decoded value (string/number/bool/array/object) or nil.
+    func evaluateJavaScript(_ js: String, timeout: TimeInterval = 10) async throws -> Any? {
+        guard let handle = engineHandle else {
+            throw BlinkBridgeError.notLoaded
+        }
+        let id = nextEvalID
+        nextEvalID += 1
+
+        return try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Any?, Error>) in
+            // Thread-safe one-shot gate: exactly one of {eval completion, timer}
+            // may resume the continuation (callbacks and the wall-clock timer
+            // race on different threads).
+            let gate = EvalGate()
+            let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+            timer.schedule(deadline: .now() + timeout)
+            timer.setEventHandler { [weak self] in
+                guard gate.markDone() else { return }
+                Task { @MainActor [weak self] in
+                    self?.pendingEvalCompletions.removeValue(forKey: id)
+                    cont.resume(throwing: JSEvalTimeout())
+                }
+            }
+            pendingEvalCompletions[id] = { value, error in
+                guard gate.markDone() else { return }
+                timer.cancel()
+                if let error {
+                    cont.resume(throwing: error)
+                } else {
+                    cont.resume(returning: value)
+                }
+            }
+            timer.resume()
+
+            BlinkEngineBridge.evaluateJavaScript(handle, js) { [weak self] value, error in
+                Task { @MainActor [weak self] in
+                    self?.pendingEvalCompletions[id]?(value, error)
+                }
+            }
+        }
+    }
+
+    // MARK: Snapshot
+
+    func captureSnapshot() async throws -> UIImage {
+        guard let handle = engineHandle else {
+            throw BlinkBridgeError.notLoaded
+        }
+        let data = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Data, Error>) in
+            BlinkEngineBridge.captureSnapshot(handle) { data, error in
+                if let data {
+                    cont.resume(returning: data)
+                } else {
+                    cont.resume(throwing: error ?? BlinkBridgeError.snapshotFailed)
+                }
+            }
+        }
+        guard let image = UIImage(data: data) else {
+            throw BlinkBridgeError.snapshotFailed
+        }
+        return image
+    }
+
+    // MARK: Events
+
+    private func handleBridgeEvent(_ payload: BlinkEngineBridge.BridgeEventPayload) {
+        switch payload.event {
+        case .didStartProvisionalNavigation:
+            isLoading = true
+            if let url = payload.url { currentURL = url }
+            onStateChange?(currentURL, nil, true)
+
+        case .didFinishNavigation:
+            isLoading = false
+            refreshState()
+            onStateChange?(currentURL, pageTitle, false)
+
+        case .didFailNavigation:
+            isLoading = false
+            onLoadFailed?(payload.url ?? currentURL, payload.error)
+
+        case .titleChanged:
+            if let title = payload.title {
+                pageTitle = title
+            }
+            onStateChange?(nil, pageTitle, nil)
+
+        case .urlChanged:
+            if let url = payload.url {
+                currentURL = url
+            }
+            onStateChange?(currentURL, nil, nil)
+
+        case .loadingStateChanged:
+            if let loading = payload.loading {
+                isLoading = loading
+            }
+            onStateChange?(nil, nil, isLoading)
+
+        case .windowOpenBlocked:
+            onWindowOpenBlocked?(payload.url)
+
+        case .renderProcessGone:
+            onRenderProcessGone?()
+        }
+        refreshState()
+    }
+
+    private func refreshState() {
+        guard let handle = engineHandle else { return }
+        let url = BlinkEngineBridge.getURL(handle)
+        if !url.isEmpty { currentURL = url }
+        let title = BlinkEngineBridge.getTitle(handle)
+        if !title.isEmpty { pageTitle = title }
+        canGoBack = BlinkEngineBridge.canGoBack(handle)
+        canGoForward = BlinkEngineBridge.canGoForward(handle)
+        isLoading = BlinkEngineBridge.isLoading(handle)
+    }
+}
+
+struct JSEvalTimeout: LocalizedError {
+    var errorDescription: String? { "JS 执行超时" }
+}
+
+/// Thread-safe one-shot gate for eval/timeout races.
+final class EvalGate: @unchecked Sendable {
+    private let lock = NSLock()
+    private var done = false
+    func markDone() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if done { return false }
+        done = true
+        return true
+    }
+}
+
+// MARK: - Blink Tab Session
+
+/// One Blink tab's runtime state + agent-facing helpers, owned by
+/// `BrowserEngineCoordinator` (one per `BrowserUseManager`).
+@MainActor
+final class BlinkTabSession {
+
+    let webView: BlinkWebView
+
+    /// Closures the manager wires in to keep its @Published state in sync.
+    var onURLChange: ((String) -> Void)?
+    var onTitleChange: ((String) -> Void)?
+    var onLoadingChange: ((Bool) -> Void)?
+    var onBackForwardChange: ((Bool, Bool) -> Void)?
+    var onLoadFailed: ((String?, String?) -> Void)?
+    var onWindowOpenBlocked: ((String?) -> Void)?
+
+    /// JS injected at document start for desktop viewport emulation (mirrors
+    /// the WKWebView path's desktopViewportScript).
+    private static let desktopViewportScript: (Int) -> String = { width in
+        """
+        (function() {
+            var w = \(width);
+            function apply() {
+                var metas = document.querySelectorAll('meta[name="viewport"]');
+                metas.forEach(function(m) { m.parentNode.removeChild(m); });
+                var m = document.createElement('meta');
+                m.name = 'viewport';
+                m.content = 'width=' + w + ', initial-scale=1.0, user-scalable=yes';
+                (document.head || document.documentElement).appendChild(m);
+            }
+            apply();
+            document.addEventListener('DOMContentLoaded', apply);
+        })();
+        """
+    }
+
+    init(frame: CGRect, userAgent: String) {
+        let wv = BlinkWebView(frame: frame)
+        self.webView = wv
+        wv.setUserAgent(userAgent)
+        wv.onStateChange = { [weak self] url, title, loading in
+            guard let self else { return }
+            if let url { self.onURLChange?(url) }
+            if let title { self.onTitleChange?(title) }
+            if let loading { self.onLoadingChange?(loading) }
+            self.onBackForwardChange?(wv.canGoBack, wv.canGoForward)
+        }
+        wv.onLoadFailed = { [weak self] url, error in
+            self?.onLoadFailed?(url, error)
+        }
+        wv.onWindowOpenBlocked = { [weak self] url in
+            self?.onWindowOpenBlocked?(url)
+        }
+    }
+
+    func loadURL(_ urlString: String) {
+        webView.loadURL(urlString)
+    }
+
+    /// Apply desktop/mobile viewport emulation for the current page.
+    func applyViewportEmulation(desktop: Bool, width: Int) {
+        let js = desktop ? Self.desktopViewportScript(width) : """
+        (function() {
+            var m = document.createElement('meta');
+            m.name = 'viewport';
+            m.content = 'width=device-width, initial-scale=1.0';
+            (document.head || document.documentElement).appendChild(m);
+        })();
+        """
+        Task {
+            try? await webView.evaluateJavaScript(js, timeout: 3)
+        }
+    }
+}

--- a/src/ios/Agent/BrowserUse/Engine/BrowserEngineCoordinator.swift
+++ b/src/ios/Agent/BrowserUse/Engine/BrowserEngineCoordinator.swift
@@ -1,0 +1,288 @@
+import Foundation
+import UIKit
+import os.log
+
+private let coordLog = AppLogger(category: "EngineCoord")
+
+// MARK: - BrowserEngineCoordinator
+
+/// Facade used by `BrowserUseManager` to route browser work to the active
+/// engine (`.webkit` = the manager's own WKWebView path, untouched; `.blink` =
+/// embedded Chromium; `.ssr` = server-side rendered fetch).
+///
+/// The manager keeps its full agent logic; only the raw web calls (load / JS /
+/// snapshot / UA / viewport / cookies / fetch) go through this coordinator.
+@MainActor
+final class BrowserEngineCoordinator {
+
+    let kind: BrowserEngineKind
+
+    /// The Blink session, non-nil only when kind == .blink and init succeeded.
+    private(set) var blinkSession: BlinkTabSession?
+
+    /// SSR manager, non-nil only when kind == .ssr.
+    private(set) var ssr: SSRManager?
+
+    /// UIView to embed in the browser sheet: Blink view / SSR placeholder / nil (webkit).
+    var renderView: UIView? {
+        blinkSession?.webView ?? ssrPlaceholderView
+    }
+
+    /// Placeholder shown in SSR mode (the browser sheet still renders a surface).
+    private var ssrPlaceholderView: UIView?
+
+    // MARK: Manager state sync (wired by BrowserUseManager)
+
+    var onURLChange: ((String) -> Void)?
+    var onTitleChange: ((String) -> Void)?
+    var onLoadingChange: ((Bool) -> Void)?
+    var onBackForwardChange: ((Bool, Bool) -> Void)?
+    var onLoadFailed: ((String?, String?) -> Void)?
+    var onWindowOpenBlocked: ((String?) -> Void)?
+
+    /// The effective UA string (used by Blink and SSR raw fetch).
+    let userAgent: String
+
+    // MARK: Init
+
+    /// - Parameters:
+    ///   - kind: requested engine kind (`.blink` downgrades to `.webkit` if
+    ///     the framework is missing or init fails).
+    ///   - frame: initial view frame.
+    ///   - userAgent: UA string for Blink + SSR.
+    ///   - desktop: whether the profile wants desktop layout.
+    ///   - viewportSize: logical viewport (w, h).
+    init(kind: BrowserEngineKind,
+         frame: CGRect,
+         userAgent: String,
+         desktop: Bool,
+         viewportSize: (width: Int, height: Int)) {
+        self.userAgent = userAgent
+
+        switch kind {
+        case .blink:
+            if BlinkEngineBridge.isFrameworkPresent() {
+                if !BlinkEngineBridge.initialize() {
+                    coordLog.error("Blink init failed — falling back to WebKit")
+                    self.kind = .webkit
+                    return
+                }
+                let session = BlinkTabSession(frame: frame, userAgent: userAgent)
+                self.blinkSession = session
+                self.kind = .blink
+                wireBlink(session)
+            } else {
+                coordLog.info("Blink framework absent — falling back to WebKit")
+                self.kind = .webkit
+            }
+
+        case .ssr:
+            self.ssr = SSRManager()
+            self.kind = .ssr
+            let placeholder = UIView(frame: frame)
+            placeholder.backgroundColor = .systemBackground
+            let label = UILabel()
+            label.text = "SSR 模式：无实时渲染\nagent 将获取页面文本内容"
+            label.numberOfLines = 0
+            label.textAlignment = .center
+            label.textColor = .secondaryLabel
+            label.font = .systemFont(ofSize: 15)
+            label.translatesAutoresizingMaskIntoConstraints = false
+            placeholder.addSubview(label)
+            NSLayoutConstraint.activate([
+                label.centerXAnchor.constraint(equalTo: placeholder.centerXAnchor),
+                label.centerYAnchor.constraint(equalTo: placeholder.centerYAnchor),
+                label.leadingAnchor.constraint(greaterThanOrEqualTo: placeholder.leadingAnchor, constant: 24),
+                label.trailingAnchor.constraint(lessThanOrEqualTo: placeholder.trailingAnchor, constant: -24)
+            ])
+            self.ssrPlaceholderView = placeholder
+
+        case .webkit:
+            self.kind = .webkit
+        }
+    }
+
+    private func wireBlink(_ session: BlinkTabSession) {
+        session.onURLChange = { [weak self] url in self?.onURLChange?(url) }
+        session.onTitleChange = { [weak self] t in self?.onTitleChange?(t) }
+        session.onLoadingChange = { [weak self] l in self?.onLoadingChange?(l) }
+        session.onBackForwardChange = { [weak self] b, f in self?.onBackForwardChange?(b, f) }
+        session.onLoadFailed = { [weak self] url, err in self?.onLoadFailed?(url, err) }
+        session.onWindowOpenBlocked = { [weak self] url in self?.onWindowOpenBlocked?(url) }
+    }
+
+    // MARK: Navigation
+
+    func navigate(to urlString: String) async throws -> String {
+        switch kind {
+        case .blink:
+            guard let session = blinkSession else { throw BlinkBridgeError.notLoaded }
+            session.loadURL(urlString)
+            return try await waitForNavigation(session)
+
+        case .ssr:
+            guard let ssr else { throw SSRManagerError.allSourcesFailed }
+            let page = try await ssr.navigate(to: urlString)
+            onURLChange?(page.url)
+            onTitleChange?(page.title)
+            onLoadingChange?(false)
+            return "[SSR \(page.source)] \(page.title) — \(page.url)\n\n\(page.markdown.prefix(3000))"
+
+        case .webkit:
+            // WebKit path is handled by the manager itself; this is unreachable.
+            throw EngineCoordinatorError.webkitPathUnreachable
+        }
+    }
+
+    /// Wait for didFinish/didFail or timeout (mirrors the WKWebView nav wait).
+    private func waitForNavigation(_ session: BlinkTabSession) async throws -> String {
+        let timeout: TimeInterval = 30
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if !session.webView.isLoading {
+                // Settle briefly so title/URL events flush through.
+                try? await Task.sleep(nanoseconds: 150_000_000)
+                return try await navigationSummary(session)
+            }
+            try? await Task.sleep(nanoseconds: 100_000_000)
+        }
+        return try await navigationSummary(session)
+    }
+
+    /// Build the navigate() result text (title/url/snippet) — Blink version of
+    /// the manager's `navigationMetadata()`.
+    private func navigationSummary(_ session: BlinkTabSession) async throws -> String {
+        let js = """
+        (function() {
+            var h1 = document.querySelector('h1');
+            var p = document.querySelector('p');
+            var desc = document.querySelector('meta[name="description"]');
+            var text = (document.body ? document.body.innerText : '').trim();
+            return JSON.stringify({
+                title: document.title || '',
+                url: location.href || '',
+                heading: h1 ? h1.innerText.trim().slice(0, 200) : '',
+                paragraph: p ? p.innerText.trim().slice(0, 300) : '',
+                textLength: text.length,
+                snippet: text.slice(0, 800)
+            });
+        })()
+        """
+        let result = try? await session.webView.evaluateJavaScript(js, timeout: 5)
+        var parts: [String] = []
+        if let dict = result as? [String: Any] {
+            if let title = dict["title"] as? String, !title.isEmpty { parts.append("**\(title)**") }
+            if let url = dict["url"] as? String, !url.isEmpty { parts.append("URL: \(url)") }
+            if let heading = dict["heading"] as? String, !heading.isEmpty { parts.append("H1: \(heading)") }
+            if let paragraph = dict["paragraph"] as? String, !paragraph.isEmpty { parts.append(paragraph) }
+            if let snippet = dict["snippet"] as? String, !snippet.isEmpty { parts.append("...\(snippet)...") }
+            if let len = dict["textLength"] as? Int { parts.append("(页面文本 \(len) 字符)") }
+        }
+        if parts.isEmpty {
+            return "已加载 \(session.webView.currentURL)"
+        }
+        return parts.joined(separator: "\n")
+    }
+
+    // MARK: JS evaluation
+
+    func evaluateJavaScript(_ js: String, timeout: TimeInterval = 10) async throws -> Any? {
+        switch kind {
+        case .blink:
+            guard let session = blinkSession else { throw BlinkBridgeError.notLoaded }
+            return try await session.webView.evaluateJavaScript(js, timeout: timeout)
+        case .ssr:
+            throw EngineCoordinatorError.ssrNoJavaScript
+        case .webkit:
+            throw EngineCoordinatorError.webkitPathUnreachable
+        }
+    }
+
+    // MARK: Snapshot
+
+    func takeScreenshot() async throws -> UIImage {
+        switch kind {
+        case .blink:
+            guard let session = blinkSession else { throw BlinkBridgeError.notLoaded }
+            return try await session.webView.captureSnapshot()
+        case .ssr:
+            return UIImage.ssrPlaceholder(text: ssr?.currentPage?.markdown ?? "SSR 模式：无实时渲染")
+        case .webkit:
+            throw EngineCoordinatorError.webkitPathUnreachable
+        }
+    }
+
+    // MARK: Controls
+
+    func goBack() {
+        if kind == .blink { blinkSession?.webView.goBack() }
+    }
+
+    func goForward() {
+        if kind == .blink { blinkSession?.webView.goForward() }
+    }
+
+    func reload() {
+        if kind == .blink { blinkSession?.webView.reload() }
+    }
+
+    func stopLoading() {
+        if kind == .blink { blinkSession?.webView.stopLoading() }
+        if kind == .ssr { onLoadingChange?(false) }
+    }
+
+    func setUserAgent(_ ua: String) {
+        if kind == .blink { blinkSession?.webView.setUserAgent(ua) }
+    }
+
+    func applyViewport(desktop: Bool, width: Int) {
+        if kind == .blink {
+            blinkSession?.applyViewportEmulation(desktop: desktop, width: width)
+        }
+    }
+
+    // MARK: Fetch (engine-independent)
+
+    /// Download a resource via URLSession (works for blink/ssr; webkit uses
+    /// the manager's in-page fetch path).
+    func fetchData(from url: URL) async throws -> (data: Data, response: URLResponse) {
+        var request = URLRequest(url: url, timeoutInterval: 30)
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        return try await URLSession.shared.data(for: request)
+    }
+
+    // MARK: Page info
+
+    func currentPageInfo() -> (url: String, title: String, isLoading: Bool, canGoBack: Bool, canGoForward: Bool) {
+        switch kind {
+        case .blink:
+            guard let wv = blinkSession?.webView else { return ("", "", false, false, false) }
+            return (wv.currentURL, wv.pageTitle, wv.isLoading, wv.canGoBack, wv.canGoForward)
+        case .ssr:
+            let page = ssr?.currentPage
+            return (page?.url ?? "", page?.title ?? "", false, false, false)
+        case .webkit:
+            return ("", "", false, false, false)
+        }
+    }
+
+    // MARK: Teardown
+
+    func teardown() {
+        blinkSession = nil
+        ssr = nil
+        ssrPlaceholderView = nil
+    }
+}
+
+enum EngineCoordinatorError: LocalizedError {
+    case webkitPathUnreachable
+    case ssrNoJavaScript
+
+    var errorDescription: String? {
+        switch self {
+        case .webkitPathUnreachable: return "WebKit 路径由 manager 直接处理（协调器不应被调用）"
+        case .ssrNoJavaScript: return "SSR 模式不支持执行 JavaScript（无浏览器进程）。请切换 WebKit/Blink 引擎后重试。"
+        }
+    }
+}

--- a/src/ios/Agent/BrowserUse/Engine/BrowserEngineKind.swift
+++ b/src/ios/Agent/BrowserUse/Engine/BrowserEngineKind.swift
@@ -1,0 +1,92 @@
+import Foundation
+import UIKit
+
+// MARK: - Browser Engine Kind
+
+/// Rendering engine used by browser tabs.
+///
+/// - `.webkit`: system WKWebView (default, always available).
+/// - `.blink`: embedded Chromium Blink+V8 (`content_shell_framework.framework`,
+///   dlopen'd at runtime — only present in the TrollStore/Blink build).
+/// - `.ssr`: server-side rendered content fetch (r.jina.ai / raw HTML / Wayback).
+///   Headless: returns text/readable content instead of a live viewport.
+enum BrowserEngineKind: String, CaseIterable, Identifiable, Sendable {
+    case webkit
+    case blink
+    case ssr
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .webkit: return "WebKit"
+        case .blink: return "Blink (Chromium)"
+        case .ssr: return "SSR (服务器渲染)"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .webkit: return "safari"
+        case .blink: return "globe.asia.australia.fill"
+        case .ssr: return "text.document"
+        }
+    }
+
+    /// Short badge shown in the browser toolbar.
+    var badge: String {
+        switch self {
+        case .webkit: return "WK"
+        case .blink: return "BLINK"
+        case .ssr: return "SSR"
+        }
+    }
+
+    var blurb: String {
+        switch self {
+        case .webkit: return "系统 WKWebView，与 iOS 系统同步"
+        case .blink: return "真实 Chromium Blink+V8 引擎（iOS 16 越狱/TrollStore 构建）"
+        case .ssr: return "服务器端渲染抓取文本内容，无需设备渲染"
+        }
+    }
+}
+
+// MARK: - Engine Settings
+
+/// App-level engine selection, persisted in UserDefaults.
+@MainActor
+final class BrowserEngineSettings {
+    static let shared = BrowserEngineSettings()
+
+    private let defaults = UserDefaults.standard
+    private let key = "browser.engine.kind"
+
+    /// Current engine. `.blink` silently falls back to `.webkit` at tab
+    /// creation time when the Blink framework isn't bundled (plain build).
+    var kind: BrowserEngineKind {
+        get {
+            guard let raw = defaults.string(forKey: key),
+                  let k = BrowserEngineKind(rawValue: raw) else {
+                return .webkit
+            }
+            return k
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: key)
+        }
+    }
+
+    /// The kind actually usable right now (respects framework presence).
+    var effectiveKind: BrowserEngineKind {
+        if kind == .blink && !BlinkEngineBridge.isFrameworkPresent() {
+            return .webkit
+        }
+        return kind
+    }
+
+    /// Blink requires the `content_shell_framework.framework` inside the app
+    /// bundle — only true for the Blink/TrollStore build.
+    static var isBlinkBuild: Bool {
+        BlinkEngineBridge.isFrameworkPresent()
+    }
+}

--- a/src/ios/Agent/BrowserUse/Engine/OpenInSystemBrowser.swift
+++ b/src/ios/Agent/BrowserUse/Engine/OpenInSystemBrowser.swift
@@ -1,0 +1,33 @@
+import Foundation
+import UIKit
+
+// MARK: - P2: 用系统默认浏览器打开
+
+enum OpenInSystemBrowser {
+
+    /// Open `urlString` in the system default browser (the URL scheme handler
+    /// iOS picks — Safari or the user's default / Blinker Fluid if registered).
+    /// Returns an error message, or nil on success.
+    @MainActor
+    static func open(_ urlString: String) -> String? {
+        var normalized = urlString
+        if !normalized.contains("://") {
+            normalized = "https://\(normalized)"
+        }
+        guard let url = URL(string: normalized),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme) else {
+            return "无法打开：无效 URL（仅支持 http/https）"
+        }
+        guard UIApplication.shared.canOpenURL(url) else {
+            return "无法打开：系统没有可处理该 URL 的应用"
+        }
+        UIApplication.shared.open(url) { ok in
+            if !ok {
+                // Surface failure via the app's logger.
+                AppLogger(category: "OpenInBrowser").error("open failed for \(urlString)")
+            }
+        }
+        return nil
+    }
+}

--- a/src/ios/Agent/BrowserUse/Engine/SSRManager.swift
+++ b/src/ios/Agent/BrowserUse/Engine/SSRManager.swift
@@ -1,0 +1,260 @@
+import Foundation
+import UIKit
+import os.log
+
+private let ssrLog = AppLogger(category: "SSREngine")
+
+// MARK: - SSR Manager (P1: 服务器端渲染降级)
+
+/// Headless content-retrieval engine. When the device can't render a page
+/// (WebKit too old / Blink unavailable or crashed), the agent still gets the
+/// page's content via server-side rendering:
+///
+/// 1. **r.jina.ai** — renders the page to markdown on their servers. Must go
+///    through curl (their TLS-fingerprint ACL rejects Python urllib/URLSession);
+///    runs inside OpenMinis's embedded iSH when the kernel is booted.
+/// 2. **Raw HTML** — plain URLSession fetch + lightweight extraction.
+/// 3. **Wayback Machine** — archive.org snapshot of the URL.
+///
+/// Interactive actions (click/type/scroll) return explanatory errors — this
+/// mode is for content retrieval, not automation.
+@MainActor
+final class SSRManager {
+
+    struct SSRPage {
+        let url: String
+        let title: String
+        let markdown: String
+        let source: String  // "r.jina.ai" | "raw-html" | "wayback"
+        let truncated: Bool
+    }
+
+    private(set) var currentPage: SSRPage?
+    private var currentHTML: String = ""
+
+    /// Session id used for iSH command execution.
+    private let ishSessionId = "ssr-engine"
+
+    // MARK: - Fetch chain
+
+    func navigate(to urlString: String) async throws -> SSRPage {
+        let normalized = urlString.contains("://") ? urlString : "https://\(urlString)"
+        guard let url = URL(string: normalized), let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme) else {
+            throw SSRManagerError.invalidURL
+        }
+
+        // 1. r.jina.ai via iSH curl (TLS-fingerprint safe).
+        if isISHBooted() {
+            ssrLog.info("SSR: trying r.jina.ai for \(url.absoluteString)")
+            if let page = try? await fetchViaJina(url) {
+                currentPage = page
+                return page
+            }
+            ssrLog.info("SSR: r.jina.ai failed/blocked — falling back")
+        }
+
+        // 2. Raw HTML.
+        ssrLog.info("SSR: fetching raw HTML for \(url.absoluteString)")
+        if let page = try? await fetchRawHTML(url) {
+            currentPage = page
+            return page
+        }
+
+        // 3. Wayback.
+        ssrLog.info("SSR: trying Wayback for \(url.absoluteString)")
+        if let page = try? await fetchViaWayback(url) {
+            currentPage = page
+            return page
+        }
+
+        throw SSRManagerError.allSourcesFailed
+    }
+
+    // MARK: r.jina.ai
+
+    private func isISHBooted() -> Bool {
+        ISHKernel.shared.isBooted
+    }
+
+    private func fetchViaJina(_ url: URL) async throws -> SSRPage {
+        let target = "https://r.jina.ai/\(url.absoluteString)"
+        let command = "curl -sL --max-time 40 -A 'Mozilla/5.0 (iPhone; CPU iPhone OS 16_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.2 Mobile/15E148 Safari/604.1' '\(target)' 2>/dev/null | head -c 400000"
+
+        let result: ISHCommandResult
+        do {
+            result = try await ISHExecutionCoordinator.shared.execute(
+                sessionId: ishSessionId,
+                command: command,
+                timeout: 60,
+                lineCallback: { _ in },
+                pidCallback: { _ in }
+            )
+        } catch {
+            throw SSRManagerError.jinaUnavailable(error.localizedDescription)
+        }
+
+        let output = result.output
+        // Cloudflare interstitial detection.
+        if output.contains("Just a moment") || output.contains("cf-challenge") || output.count < 200 {
+            throw SSRManagerError.jinaBlocked
+        }
+        return makePage(url: url.absoluteString, content: output, source: "r.jina.ai")
+    }
+
+    // MARK: Raw HTML
+
+    private func fetchRawHTML(_ url: URL) async throws -> SSRPage {
+        var request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 25)
+        request.setValue("Mozilla/5.0 (iPhone; CPU iPhone OS 16_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.2 Mobile/15E148 Safari/604.1",
+                         forHTTPHeaderField: "User-Agent")
+        request.setValue("text/html,application/xhtml+xml", forHTTPHeaderField: "Accept")
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200,
+              let html = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .isoLatin1) else {
+            throw SSRManagerError.rawFetchFailed
+        }
+        currentHTML = html
+        let extracted = Self.extractReadable(from: html)
+        return makePage(url: url.absoluteString, content: extracted.text, source: "raw-html", title: extracted.title)
+    }
+
+    // MARK: Wayback
+
+    private func fetchViaWayback(_ url: URL) async throws -> SSRPage {
+        let apiURL = "https://archive.org/wayback/available?url=\(url.absoluteString)"
+        guard let api = URL(string: apiURL) else { throw SSRManagerError.waybackUnavailable }
+        let (data, _) = try await URLSession.shared.data(from: api)
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let snapshots = json["archived_snapshots"] as? [String: Any],
+              let closest = snapshots["closest"] as? [String: Any],
+              let snapshotURL = closest["url"] as? String,
+              let snap = URL(string: snapshotURL) else {
+            throw SSRManagerError.waybackUnavailable
+        }
+        var request = URLRequest(url: snap, timeoutInterval: 25)
+        request.setValue("Mozilla/5.0", forHTTPHeaderField: "User-Agent")
+        let (htmlData, _) = try await URLSession.shared.data(for: request)
+        guard let html = String(data: htmlData, encoding: .utf8) else {
+            throw SSRManagerError.waybackUnavailable
+        }
+        currentHTML = html
+        let extracted = Self.extractReadable(from: html)
+        return makePage(url: snapshotURL, content: extracted.text, source: "wayback", title: extracted.title)
+    }
+
+    // MARK: Page assembly
+
+    private func makePage(url: String, content: String, source: String, title: String? = nil) -> SSRPage {
+        let truncated = content.count > 60_000
+        let trimmed = String(content.prefix(60_000))
+        let resolvedTitle = title ?? Self.extractTitle(from: trimmed) ?? url
+        return SSRPage(url: url, title: resolvedTitle, markdown: trimmed, source: source, truncated: truncated)
+    }
+
+    // MARK: - Text extraction (lightweight, no dependencies)
+
+    static func extractTitle(from html: String) -> String? {
+        guard let range = html.range(of: "<title[^>]*>", options: .regularExpression),
+              let end = html.range(of: "</title>", range: range.upperBound..<html.endIndex) else {
+            return nil
+        }
+        let title = String(html[range.upperBound..<end.lowerBound])
+        return Self.stripTags(title).trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? nil : Self.stripTags(title).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Minimal HTML→text extraction: title, meta description, body paragraphs.
+    static func extractReadable(from html: String) -> (title: String?, text: String) {
+        let title = extractTitle(from: html)
+
+        // Meta description.
+        var description: String? = nil
+        if let range = html.range(of: "<meta[^>]*name=[\"']description[\"'][^>]*content=[\"']([^\"']*)[\"']", options: .regularExpression) {
+            let tag = String(html[range])
+            if let c = tag.range(of: "content=[\"']([^\"']*)[\"']", options: .regularExpression) {
+                let content = String(tag[c])
+                description = Self.stripTags(content.replacingOccurrences(of: "content=[\"']", with: "").replacingOccurrences(of: "\"'", with: ""))
+            }
+        }
+
+        var body = html
+        // Drop scripts/styles/head/noscript/svg.
+        for pattern in ["<script[^>]*>[\\s\\S]*?</script>", "<style[^>]*>[\\s\\S]*?</style>",
+                        "<noscript[^>]*>[\\s\\S]*?</noscript>", "<svg[^>]*>[\\s\\S]*?</svg>",
+                        "<head[^>]*>[\\s\\S]*?</head>"] {
+            body = body.replacingOccurrences(of: pattern, with: " ", options: .regularExpression)
+        }
+        // Block tags → newlines.
+        body = body.replacingOccurrences(of: "</(p|div|h1|h2|h3|h4|h5|h6|li|tr|br|section|article|blockquote)>",
+                                         with: "\n", options: .regularExpression)
+        let stripped = Self.stripTags(body)
+        // Collapse whitespace per line, drop empties, keep meaningful lines.
+        let lines = stripped.components(separatedBy: "\n")
+            .map { $0.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+                     .trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.count >= 2 }
+        let text = lines.joined(separator: "\n")
+
+        var parts: [String] = []
+        if let title { parts.append("# \(title)") }
+        if let description, !description.isEmpty { parts.append("> \(description)") }
+        parts.append(text.isEmpty ? "(页面无可提取文本)" : text)
+        return (title, parts.joined(separator: "\n\n"))
+    }
+
+    private static func stripTags(_ s: String) -> String {
+        s.replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+            .replacingOccurrences(of: "&amp;", with: "&")
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+    }
+}
+
+enum SSRManagerError: LocalizedError {
+    case invalidURL
+    case jinaUnavailable(String)
+    case jinaBlocked
+    case rawFetchFailed
+    case waybackUnavailable
+    case allSourcesFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "SSR: 无效 URL"
+        case .jinaUnavailable(let msg): return "SSR: r.jina.ai 不可用 (\(msg))"
+        case .jinaBlocked: return "SSR: r.jina.ai 返回验证页（Cloudflare）"
+        case .rawFetchFailed: return "SSR: 原始 HTML 抓取失败"
+        case .waybackUnavailable: return "SSR: Wayback 无存档"
+        case .allSourcesFailed: return "SSR: 所有取数源均失败（r.jina.ai / 原始 HTML / Wayback）"
+        }
+    }
+}
+
+// MARK: - SSR placeholder screenshot
+
+extension UIImage {
+    /// A generated "SSR mode" placeholder so the screenshot action contract
+    /// (returns an image) holds even though SSR has no live viewport.
+    static func ssrPlaceholder(text: String) -> UIImage {
+        let size = CGSize(width: 390, height: 300)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { ctx in
+            UIColor.systemBackground.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+            let paragraph = NSMutableParagraphStyle()
+            paragraph.lineBreakMode = .byWordWrapping
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: UIFont.systemFont(ofSize: 14),
+                .foregroundColor: UIColor.label,
+                .paragraphStyle: paragraph
+            ]
+            let snippet = String(text.prefix(1200))
+            (snippet as NSString).draw(in: CGRect(x: 16, y: 16, width: size.width - 32, height: size.height - 32),
+                                       withAttributes: attrs)
+        }
+    }
+}

--- a/src/ios/Agent/Chat/AIChatViewModel+ToolDefinitions.swift
+++ b/src/ios/Agent/Chat/AIChatViewModel+ToolDefinitions.swift
@@ -94,9 +94,10 @@ extension AIChatViewModel {
                     "viewport_height": AgentToolParam(type: .integer, description: "Viewport height in CSS pixels for set_viewport (e.g. 1080). Required together with viewport_width unless reset=true."),
                     "reset": AgentToolParam(type: .boolean, description: "For set_viewport: when true, clear the session-level viewport override and fall back to the global browser setting."),
                     "full_page": AgentToolParam(type: .boolean, description: "For screenshot: capture the entire scrollable page by temporarily resizing the WebView to document.documentElement.scrollHeight. Default false captures viewport only. Capped at 32768px tall; when capped, result text includes 'Truncated: true' and the original height."),
+                    "engine": AgentToolParam(type: .string, description: "Engine to switch to (set_engine): 'webkit' (system WebKit), 'blink' (embedded Chromium Blink, TrollStore build only), or 'ssr' (server-side rendered text fetch — use when a site renders blank/unresponsive). Applies to new tabs; the current tab is rebuilt at the same URL. open_in_browser opens the current page (or 'url') in the system default browser."),
                 ],
                 required: ["tool_title", "action"],
-                propertyOrdering: ["tool_title", "action", "tab_id", "url", "selector", "text", "coordinate_x", "coordinate_y", "direction", "amount", "scroll_count", "item_selector", "script", "user_agent", "max_depth", "keywords", "fuzzy", "cookies", "timeout", "viewport_width", "viewport_height", "reset", "full_page"]
+                propertyOrdering: ["tool_title", "action", "tab_id", "url", "selector", "text", "coordinate_x", "coordinate_y", "direction", "amount", "scroll_count", "item_selector", "script", "user_agent", "max_depth", "keywords", "fuzzy", "cookies", "timeout", "viewport_width", "viewport_height", "reset", "full_page", "engine"]
             ),
         ]
 

--- a/src/ios/Minis.xcodeproj/project.pbxproj
+++ b/src/ios/Minis.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E5B1000000000000000003E9 /* BrowserEngineKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B1000000000000000003E8 /* BrowserEngineKind.swift */; };
+		E5B1000000000000000003EB /* BlinkEngineBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B1000000000000000003EA /* BlinkEngineBridge.swift */; };
+		E5B1000000000000000003ED /* BlinkTabSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B1000000000000000003EC /* BlinkTabSession.swift */; };
+		E5B1000000000000000003EF /* SSRManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B1000000000000000003EE /* SSRManager.swift */; };
+		E5B1000000000000000003F1 /* BrowserEngineCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B1000000000000000003F0 /* BrowserEngineCoordinator.swift */; };
+		E5B1000000000000000003F3 /* OpenInSystemBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5B1000000000000000003F2 /* OpenInSystemBrowser.swift */; };
 		21FED4B7BB6F6D9476C9992E /* VoiceProvider+System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88993FC8E3F0199C6638F664 /* VoiceProvider+System.swift */; };
 		241D530017827D7F0EB604DE /* VoiceProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2941B643B8A2F048A2B154E /* VoiceProviderFactory.swift */; };
 		2A4FD49F872431D703328384 /* VoiceOutputPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424510790AF3FB2452D3CCE3 /* VoiceOutputPlayer.swift */; };
@@ -542,6 +548,12 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		E5B1000000000000000003E8 /* BrowserEngineKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserEngineKind.swift; sourceTree = "<group>"; };
+		E5B1000000000000000003EA /* BlinkEngineBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlinkEngineBridge.swift; sourceTree = "<group>"; };
+		E5B1000000000000000003EC /* BlinkTabSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlinkTabSession.swift; sourceTree = "<group>"; };
+		E5B1000000000000000003EE /* SSRManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSRManager.swift; sourceTree = "<group>"; };
+		E5B1000000000000000003F0 /* BrowserEngineCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserEngineCoordinator.swift; sourceTree = "<group>"; };
+		E5B1000000000000000003F2 /* OpenInSystemBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenInSystemBrowser.swift; sourceTree = "<group>"; };
 		0ED149397BEA7E0408C92688 /* GroupVoiceModelsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupVoiceModelsView.swift; sourceTree = "<group>"; };
 		0F5379380323FA8C6477708C /* GroupSlotPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupSlotPicker.swift; sourceTree = "<group>"; };
 		16FF3462D09402F14B610CD6 /* VoiceWaveformView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceWaveformView.swift; sourceTree = "<group>"; };
@@ -1135,6 +1147,19 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		E5B10000000000000000000E /* Engine */ = {
+			isa = PBXGroup;
+			children = (
+				E5B1000000000000000003E8 /* BrowserEngineKind.swift */,
+				E5B1000000000000000003EA /* BlinkEngineBridge.swift */,
+				E5B1000000000000000003EC /* BlinkTabSession.swift */,
+				E5B1000000000000000003EE /* SSRManager.swift */,
+				E5B1000000000000000003F0 /* BrowserEngineCoordinator.swift */,
+				E5B1000000000000000003F2 /* OpenInSystemBrowser.swift */,
+			);
+			path = Engine;
+			sourceTree = "<group>";
+		};
 		42A3821DABA8773E8A5BA57E /* Voice */ = {
 			isa = PBXGroup;
 			children = (
@@ -1451,7 +1476,8 @@
 		E57000030 /* BrowserUse */ = {
 			isa = PBXGroup;
 			children = (
-				E57000011 /* BrowserUseActions.swift */,
+								E5B10000000000000000000E /* Engine */,
+E57000011 /* BrowserUseActions.swift */,
 				E57000012 /* BrowserUseJavaScript.swift */,
 				E57000013 /* BrowserUseManager.swift */,
 				E57000014 /* BrowserWebView.swift */,
@@ -2604,6 +2630,12 @@
 				E53000005 /* UsageStatsView.swift in Sources */,
 				E53000006 /* CacheKeepAliveManager.swift in Sources */,
 				E57000001 /* BrowserUseActions.swift in Sources */,
+		E5B1000000000000000003E9 /* BrowserEngineKind.swift in Sources */,
+		E5B1000000000000000003EB /* BlinkEngineBridge.swift in Sources */,
+		E5B1000000000000000003ED /* BlinkTabSession.swift in Sources */,
+		E5B1000000000000000003EF /* SSRManager.swift in Sources */,
+		E5B1000000000000000003F1 /* BrowserEngineCoordinator.swift in Sources */,
+		E5B1000000000000000003F3 /* OpenInSystemBrowser.swift in Sources */,
 				E57000002 /* BrowserUseJavaScript.swift in Sources */,
 				E57000003 /* BrowserUseManager.swift in Sources */,
 				E57000004 /* BrowserWebView.swift in Sources */,


### PR DESCRIPTION
# OpenMinis Blink Engine (iOS 16 真实浏览器引擎)

在 OpenMinis 中嵌入真实 Chromium Blink+V8 渲染引擎，替换/补充 WKWebView，让 iOS 16.2 越狱设备（A12Z / TrollStore）上的现代网站正常渲染。

## 背景

- 设备：iPad Pro 2020 (A12Z, arm64e)，iOS 16.2，已越狱，TrollStore 侧载
- 问题：WKWebView 引擎随系统锁死（iOS 16.2 的 WebKit 太老），现代网站白屏、按钮无响应
- BrowserEngineKit 需要 iOS 17.4+，不可用
- 参考实现：**Blinker Fluid**（https://github.com/Ssabal/blinker-fluid）已成功把 Chromium Blink+V8 移植到 iOS 14–16 越狱设备，其产物为 `content_shell.app` + `content_shell_framework.framework`（263MB 单一 dylib，无签名，TrollStore 安装时签名）

## 方案优先级

| 级别 | 方案 | 状态 |
|------|------|------|
| P0 | 嵌入 Chromium Blink+V8，替换 WKWebView 渲染，agent 自动化接口不变 | 本分支实现（CI 构建） |
| P1 | 渲染失败自动降级服务器端渲染取内容（r.jina.ai + 原始 HTML + Wayback，curl 防 TLS 指纹反爬） | 本分支实现（SSR 引擎） |
| P2 | "用系统默认浏览器打开"选项 | 本分支实现（open_in_browser） |

## 架构

```
BrowserSheetView / BrowserTabPool
        │
        ▼
BrowserUseManager  (agent 动作执行器，现有 2640 行逻辑不动)
        │  engineKind: .webkit | .blink | .ssr
        ├── .webkit ──► WKWebView（现有路径，行为 100% 不变）
        ├── .blink  ──► BrowserEngineCoordinator ──► BlinkTabSession ──► BlinkEngineBridge
        │                                                    (dlopen + dlsym) │
        │                                                                    ▼
        │                                          content_shell_framework.framework
        │                                          （Chromium 149 + Blinker Fluid 补丁 + blink_bridge C API）
        └── .ssr    ──► BrowserEngineCoordinator ──► SSRManager
                                           (r.jina.ai 经 iSH curl / 原始 HTML / Wayback)
```

### 为什么用 dlopen 而不是静态链接

- `content_shell_framework.framework` 是单一 263MB dylib，由 CI 构建（macOS 上 xcodebuild 无法编译 Chromium）