### PR TITLE
feat: keep iSH alive in background when terminal is open

### DIFF
--- a/src/ios/Agent/Background/BackgroundKeepAliveManager.swift
+++ b/src/ios/Agent/Background/BackgroundKeepAliveManager.swift
@@ -1332,6 +1332,32 @@ final class BackgroundKeepAliveManager: NSObject, ObservableObject, CLLocationMa
         logger.info("[BKA][Stop] engine.stop() + end(.backgroundKeepAlive)")
     }
 
+    // MARK: - Terminal Keep-Alive
+
+    /// Stable synthetic session ID injected while the built-in terminal is open.
+    /// Using a fixed string (not a real UUID) means repeated open/close cycles
+    /// always use the same key, so the tracker never accumulates ghost entries.
+    private let terminalSessionId = "minis-terminal-keepalive"
+
+    /// Called when the user opens the built-in Shell Terminal.
+    /// Registers a synthetic session so BackgroundKeepAliveManager treats the
+    /// terminal as an "active" task — silent audio and location keep-alive both
+    /// engage when Enhanced Background is on, keeping the iSH process alive
+    /// after the user switches away.  No-op when Enhanced Background is off.
+    func registerTerminalSession() {
+        guard enhancedBackgroundEffective else { return }
+        SessionActivityTracker.shared.setActive(terminalSessionId, source: "terminal")
+        logger.info("[BKA] Terminal keep-alive REGISTERED")
+    }
+
+    /// Called when the built-in Shell Terminal is dismissed.
+    /// Removes the synthetic session so keep-alive can deactivate normally
+    /// once no real agent tasks are running either.
+    func unregisterTerminalSession() {
+        SessionActivityTracker.shared.setInactive(terminalSessionId, source: "terminal")
+        logger.info("[BKA] Terminal keep-alive UNREGISTERED")
+    }
+
     // MARK: - Live Activity Updates
 
     /// Shared method to push a Live Activity update. Called from:

--- a/src/ios/Views/Rootfs/ISHTerminalView.swift
+++ b/src/ios/Views/Rootfs/ISHTerminalView.swift
@@ -120,9 +120,17 @@ struct ISHTerminalView: View {
             // room for the sheet, and the user sees "terminal closes,
             // browser opens, loading forever". Cleared in .onDisappear.
             MinisOpenURLBroker.shared.terminalVisible = true
+            // Register terminal session so silent-audio + location keep-alive
+            // engage while the terminal is open (no-op when Enhanced Background
+            // is off). This keeps the iSH process alive after the user switches
+            // to another app, which is the primary use-case for the terminal.
+            BackgroundKeepAliveManager.shared.registerTerminalSession()
         }
         .onDisappear {
             MinisOpenURLBroker.shared.terminalVisible = false
+            // Release the synthetic keep-alive session so the background
+            // machinery can deactivate when no real agent tasks are running.
+            BackgroundKeepAliveManager.shared.unregisterTerminalSession()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillShowNotification)) { note in
             let end = (note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect) ?? .zero


### PR DESCRIPTION
## Problem

When a user opens the built-in Shell Terminal and switches to another app, the Minis process may be suspended by iOS, killing any running shell commands (e.g. a long-running script, a server, or a `sleep` loop). The terminal has no way to stay alive in the background today.

## Solution

Hook into the **existing** `BackgroundKeepAliveManager` keep-alive machinery that already backs the agent loop. When the terminal opens, register a synthetic keep-alive session — this causes `reevaluate()` to flip `isActive = true`, which in turn starts:

- **Silent audio** (`AVAudioEngine` at volume 0.001) — keeps the app process alive indefinitely
- **Background location** (`CLBackgroundActivitySession`) — secondary keep-alive leg (iOS 17+)

Both legs are already implemented and tested for the agent loop; this PR simply reuses them for the terminal.

## Changes

### `BackgroundKeepAliveManager.swift`
Add two public methods and a private constant:

```swift
private let terminalSessionId = "minis-terminal-keepalive"

func registerTerminalSession() {
    guard enhancedBackgroundEffective else { return }
    SessionActivityTracker.shared.setActive(terminalSessionId, source: "terminal")
    logger.info("[BKA] Terminal keep-alive REGISTERED")
}

func unregisterTerminalSession() {
    SessionActivityTracker.shared.setInactive(terminalSessionId, source: "terminal")
    logger.info("[BKA] Terminal keep-alive UNREGISTERED")
}
```

### `ISHTerminalView.swift`
Call `register`/`unregister` in `.onAppear`/`.onDisappear`:

```swift
.onAppear {
    viewModel.startShell(...)
    MinisOpenURLBroker.shared.terminalVisible = true
    BackgroundKeepAliveManager.shared.registerTerminalSession()
}
.onDisappear {
    MinisOpenURLBroker.shared.terminalVisible = false
    BackgroundKeepAliveManager.shared.unregisterTerminalSession()
}
```

## Behaviour

| Enhanced Background | Result |
|---|---|
| **Off** | No change — `registerTerminalSession()` is a no-op when `enhancedBackgroundEffective` is false |
| **On** | Terminal registers a synthetic session → keep-alive activates → iSH stays alive in background |

## Testing

1. Enable Settings → Background → Enhanced Background Execution + Background Speak
2. Open the Shell Terminal from the toolbar
3. Run a long command: `while true; do date; sleep 5; done`
4. Switch to another app for > 30 seconds
5. Return to Minis — the command should still be running (no interruption)