### PR TITLE
fix: allow saving empty API key for third-party keyless endpoints

### DIFF
--- a/src/android/app/src/main/java/com/openminis/app/ui/settings/ProviderDetailScreen.kt
+++ b/src/android/app/src/main/java/com/openminis/app/ui/settings/ProviderDetailScreen.kt
@@ -967,7 +967,9 @@ private fun ApiKeyCredentialBlock(
                 Text(stringResource(R.string.common_cancel))
             }
             Spacer(modifier = Modifier.width(8.dp))
-            MinisSmallButton(onClick = onSave, enabled = editValue.isNotBlank()) {
+            // [T-empty-key-compat-endpoints] Allow saving empty key for
+            // third-party keyless endpoints (ollama, OpenCode Zen free, etc.)
+            MinisSmallButton(onClick = onSave) {
                 Text(stringResource(R.string.provider_detail_save_key))
             }
         }


### PR DESCRIPTION
## Problem

The ProviderDetailScreen API key save button requires `editValue.isNotBlank()`, blocking empty key saves for third-party keyless endpoints (ollama, LM Studio, OpenCode Zen free tier, etc.).

The providers already support keyless — empty key means no `Authorization` header. Only the edit UI blocks it.

## Fix

Remove the `enabled = editValue.isNotBlank()` guard from the save button in `ApiKeyCredentialBlock`.

Fixes #218