### PR TITLE
feat(voice): per-model voiceOverride for TTS providers

### DIFF
--- a/src/android/app/src/main/java/com/openminis/app/config/collections/ModelsCollection.kt
+++ b/src/android/app/src/main/java/com/openminis/app/config/collections/ModelsCollection.kt
@@ -51,6 +51,7 @@ class ModelsCollection(
             modalitiesOverrideField(forId),
             contextWindowField(forId),
             contextWindowOverrideField(forId),
+            voiceOverrideField(forId),
             supportsToolsField(forId),
             supportsVisionField(forId),
         )
@@ -388,6 +389,25 @@ class ModelsCollection(
                 mutate(id) { e ->
                     e.copy(overrides = e.overrides.copy(contextWindow = if (i == 0) null else i))
                 }
+            },
+        )
+
+    private fun voiceOverrideField(id: String): ConfigField =
+        ClosureField(
+            path = "models.$id.voiceOverride",
+            displayName = "Voice override",
+            description = "User-set TTS voice id. Sent as the `voice` field of /v1/audio/speech (or audio-modal requests). Empty restores the provider default.",
+            valueSchema = ConfigSchema.Str(maxLength = 256),
+            risk = ConfigRisk.SENSITIVE,
+            revertable = true,
+            reader = {
+                val e = entry(id) ?: return@ClosureField ConfigValue.Null
+                val v = e.overrides.voiceOverride
+                if (v.isNullOrEmpty()) ConfigValue.Null else ConfigValue.Str(v)
+            },
+            writer = { v ->
+                val s = (v as? ConfigValue.Str)?.value ?: throw ConfigError.TypeMismatch("string")
+                mutate(id) { e -> e.copy(overrides = e.overrides.copy(voiceOverride = s.ifEmpty { null })) }
             },
         )
 

--- a/src/android/app/src/main/java/com/openminis/app/data/model/ProviderConfig.kt
+++ b/src/android/app/src/main/java/com/openminis/app/data/model/ProviderConfig.kt
@@ -347,6 +347,10 @@ data class ModelOverrides(
     // of older JSON (unlike adding an enum case) — old configs simply lack the
     // key and it defaults to null.
     val maxThinkingLevel: ThinkingLevel? = null,
+    // User-set TTS voice id (OpenAI /v1/audio/speech `voice` field, or audio-modal
+    // voice token). Sent verbatim when set; null = provider default. Mirrors iOS
+    // ModelOverrides.voiceOverride. Optional field = safe for old config JSON.
+    val voiceOverride: String? = null,
 ) {
     val isEmpty: Boolean
         get() = displayName == null
@@ -356,6 +360,7 @@ data class ModelOverrides(
             && inputModalities == null
             && outputModalities == null
             && maxThinkingLevel == null
+            && voiceOverride == null
 }
 
 @Serializable

--- a/src/android/app/src/main/java/com/openminis/app/speech/ReadAloudPlayer.kt
+++ b/src/android/app/src/main/java/com/openminis/app/speech/ReadAloudPlayer.kt
@@ -412,13 +412,13 @@ class ReadAloudPlayer(context: Context) {
         val data = try {
             withContext(Dispatchers.IO) {
                 voice.synthesize(
-                    // The entry id doubles as the voice id — template voices carry
-                    // the voice id as the model id (same convention QuickTestSheet
-                    // relies on, iOS 0a52bdbf).
+                    // Template voices carry the voice id as the model id; an explicit
+                    // per-entry voiceOverride (e.g. a fish reference_id on a plain
+                    // TTS model) wins when set. Mirrors iOS voice-override support.
                     VoiceOutputRequest(
                         input = text,
                         model = modelEntry.model.id,
-                        voice = modelEntry.model.id,
+                        voice = modelEntry.overrides.voiceOverride ?: modelEntry.model.id,
                     ),
                 )
             }

--- a/src/android/app/src/main/java/com/openminis/app/ui/components/QuickTestSheet.kt
+++ b/src/android/app/src/main/java/com/openminis/app/ui/components/QuickTestSheet.kt
@@ -475,14 +475,13 @@ internal suspend fun performTest(
                 } else {
                     runCatching {
                         // The selected entry id is the model AND the voice id
-                        // (template voices carry the voice id as the model id) —
-                        // iOS 0a52bdbf: pass entry.model.id for both so the test
-                        // speaks in THAT voice, not the vendor default.
+                        // (template voices carry the voice id as the model id); an
+                        // explicit per-entry voiceOverride wins when set — iOS 0a52bdbf.
                         val data = voice.synthesize(
                             com.openminis.app.provider.voice.VoiceOutputRequest(
                                 input = "Hi! This is Minis testing text to speech.",
                                 model = entry.model.id,
-                                voice = entry.model.id,
+                                voice = entry.overrides.voiceOverride ?: entry.model.id,
                             ),
                         )
                         if (data.isEmpty()) {

--- a/src/ios/Providers/ModelEntry.swift
+++ b/src/ios/Providers/ModelEntry.swift
@@ -27,19 +27,27 @@ struct ModelOverrides: Codable, Hashable, Sendable {
     /// Thinking toggle revert).
     var supportsReasoning: Bool?
     var maxThinkingLevel: ThinkingLevel?
+    /// User-set voice id for TTS (OpenAI `/v1/audio/speech` `voice` field, or
+    /// audio-modal voice token). When set, read-aloud and Quick Test send it
+    /// verbatim — this is how providers whose catalog entry is NOT itself a
+    /// voice (e.g. a fish reference_id on a plain TTS model) get a custom
+    /// voice. nil preserves today's provider-default behaviour.
+    var voiceOverride: String?
 
     init(displayName: String? = nil,
          maxOutputTokens: Int? = nil,
          modalityOverride: ModelModality? = nil,
          contextWindow: Int? = nil,
          supportsReasoning: Bool? = nil,
-         maxThinkingLevel: ThinkingLevel? = nil) {
+         maxThinkingLevel: ThinkingLevel? = nil,
+         voiceOverride: String? = nil) {
         self.displayName = displayName
         self.maxOutputTokens = maxOutputTokens
         self.modalityOverride = modalityOverride
         self.contextWindow = contextWindow
         self.supportsReasoning = supportsReasoning
         self.maxThinkingLevel = maxThinkingLevel
+        self.voiceOverride = voiceOverride
     }
 
     /// True when the user has not set any override.
@@ -50,10 +58,11 @@ struct ModelOverrides: Codable, Hashable, Sendable {
             && contextWindow == nil
             && supportsReasoning == nil
             && maxThinkingLevel == nil
+            && voiceOverride == nil
     }
 
     private enum CodingKeys: String, CodingKey {
-        case displayName, maxOutputTokens, modalityOverride, contextWindow, supportsReasoning, maxThinkingLevel
+        case displayName, maxOutputTokens, modalityOverride, contextWindow, supportsReasoning, maxThinkingLevel, voiceOverride
     }
 
     init(from decoder: Decoder) throws {
@@ -68,6 +77,7 @@ struct ModelOverrides: Codable, Hashable, Sendable {
         } else {
             self.maxThinkingLevel = nil
         }
+        self.voiceOverride = try container.decodeIfPresent(String.self, forKey: .voiceOverride)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -78,6 +88,7 @@ struct ModelOverrides: Codable, Hashable, Sendable {
         try container.encodeIfPresent(contextWindow, forKey: .contextWindow)
         try container.encodeIfPresent(supportsReasoning, forKey: .supportsReasoning)
         try container.encodeIfPresent(maxThinkingLevel?.rawValue, forKey: .maxThinkingLevel)
+        try container.encodeIfPresent(voiceOverride, forKey: .voiceOverride)
     }
 }
 

--- a/src/ios/Providers/Voice/VoiceOutputPlayer.swift
+++ b/src/ios/Providers/Voice/VoiceOutputPlayer.swift
@@ -97,6 +97,7 @@ final class VoiceOutputPlayer: NSObject, ObservableObject {
     struct Candidate {
         let key: String          // ModelEntry.id (stable identity for stickiness)
         let modelId: String?
+        let voice: String?       // entry override; nil = provider default
         let label: String
         let provider: any VoiceOutputCapable
     }
@@ -360,6 +361,7 @@ final class VoiceOutputPlayer: NSObject, ObservableObject {
             VoiceProviderResolver.resolvedOutputCandidates().compactMap { entry in
                 guard let p = VoiceProviderResolver.outputProvider(for: entry) else { return nil }
                 return Candidate(key: entry.id, modelId: entry.model.id,
+                                 voice: entry.overrides.voiceOverride,
                                  label: entry.model.displayName, provider: p)
             }
         guard !candidates.isEmpty else { return }
@@ -442,7 +444,7 @@ final class VoiceOutputPlayer: NSObject, ObservableObject {
         for (i, c) in candidates.enumerated() {
             if Task.isCancelled { throw CancellationError() }
             do {
-                let data = try await synthWithRetry(text: text, model: c.modelId, provider: c.provider, seq: seq)
+                let data = try await synthWithRetry(text: text, model: c.modelId, voice: c.voice, provider: c.provider, seq: seq)
                 if i > 0 { VoiceLog.log("TTS #\(seq): succeeded on fail-over model \(i + 1)/\(candidates.count) (\(c.label))") }
                 return (data, c)
             } catch is CancellationError {
@@ -462,14 +464,14 @@ final class VoiceOutputPlayer: NSObject, ObservableObject {
     /// synthesize+concatenate those (a too-long / partially-rejected batch often
     /// succeeds in smaller pieces). Throws only if even the split fallback fails.
     nonisolated private static func synthWithRetry(
-        text: String, model: String?, provider: any VoiceOutputCapable, seq: Int
+        text: String, model: String?, voice: String?, provider: any VoiceOutputCapable, seq: Int
     ) async throws -> Data {
         var lastError: Error?
         // Phase 1: retry the same text.
         for attempt in 0...synthRetriesSameText {
             if Task.isCancelled { throw CancellationError() }
             do {
-                return try await provider.synthesize(VoiceOutputRequest(input: text, model: model))
+                return try await provider.synthesize(VoiceOutputRequest(input: text, model: model, voice: voice))
             } catch {
                 lastError = error
                 VoiceLog.log("TTS synth retry #\(seq) attempt \(attempt + 1)/\(synthRetriesSameText + 1) failed: \(error.localizedDescription)")
@@ -487,7 +489,7 @@ final class VoiceOutputPlayer: NSObject, ObservableObject {
             var ok = false
             for attempt in 0...synthRetriesSameText {
                 do {
-                    let d = try await provider.synthesize(VoiceOutputRequest(input: chunk, model: model))
+                    let d = try await provider.synthesize(VoiceOutputRequest(input: chunk, model: model, voice: voice))
                     pieces.append(d); ok = true; break
                 } catch {
                     lastError = error

--- a/src/ios/Shared/Config/Collections/ModelsCollection.swift
+++ b/src/ios/Shared/Config/Collections/ModelsCollection.swift
@@ -43,6 +43,7 @@ struct ModelsCollection: ConfigCollection {
             modalitiesOverrideField(for: id),
             contextWindowField(for: id),
             contextWindowOverrideField(for: id),
+            voiceOverrideField(for: id),
             supportsToolsField(for: id),
             supportsVisionField(for: id),
         ]
@@ -338,6 +339,25 @@ struct ModelsCollection: ConfigCollection {
             writer: { [self] v in
                 guard case .int(let i) = v else { throw ConfigError.typeMismatch(expected: "int") }
                 try mutate(id) { $0.overrides.contextWindow = (i == 0) ? nil : i }
+            }
+        )
+    }
+
+    private func voiceOverrideField(for id: String) -> ConfigField {
+        ClosureField(
+            path: "models.\(id).voiceOverride",
+            displayName: "Voice override",
+            description: "User-set voice id for TTS. Sent as the `voice` field of /v1/audio/speech (or audio-modal requests). Empty string clears the override and restores the provider default.",
+            valueSchema: .string(maxLength: 256),
+            risk: .sensitive, revertable: true,
+            reader: { [self] in
+                guard let e = entry(id) else { return .null }
+                guard let v = e.overrides.voiceOverride, !v.isEmpty else { return .null }
+                return .string(v)
+            },
+            writer: { [self] v in
+                guard case .string(let s) = v else { throw ConfigError.typeMismatch(expected: "string") }
+                try mutate(id) { $0.overrides.voiceOverride = s.isEmpty ? nil : s }
             }
         )
     }

--- a/src/ios/Views/Providers/ModelQuickTestSheet.swift
+++ b/src/ios/Views/Providers/ModelQuickTestSheet.swift
@@ -242,7 +242,8 @@ final class TestSession: ObservableObject {
             }
             let req = VoiceOutputRequest(
                 input: "Hi! This is Minis testing text to speech.",
-                model: entry.model.id, voice: entry.model.id, speed: nil, responseFormat: .mp3)
+                model: entry.model.id, voice: entry.overrides.voiceOverride ?? entry.model.id,
+                speed: nil, responseFormat: .mp3)
             let data = try await voice.synthesize(req)
             guard !data.isEmpty else { throw QuickTestError.noOutput(AppLocalized("No audio was returned.")) }
             return .audio(data)


### PR DESCRIPTION
## Why

The app **always sent the provider default voice** (`"alloy"`) for cloud TTS read-aloud (iOS `VoiceProvider.buildVoiceOutputRequest` falls back to `defaultVoiceOutputVoice()` when `request.voice` is nil, and the read-aloud player never set it). For TTS providers whose voice is **not** the model id — e.g. a fish `reference_id` / voice-model id on a plain TTS model like `fish-audio/s2.1-pro` — there was **no way to choose the voice at all** without a local proxy rewriting the request body.

Android already had the opposite convention (read-aloud passes `voice = entry.model.id`, so voice-template entries like ElevenLabs work), but that breaks for providers needing a separate voice token, and iOS didn't pass any voice.

## What

Adds an optional **per-model-entry `voiceOverride`**:

- **`ModelOverrides.voiceOverride`** (iOS + Android) — optional `String`, persisted, survives entry refreshes, safe for existing config JSON.
- **Read-aloud (iOS `VoiceOutputPlayer`, Android `ReadAloudPlayer`)** — sends `voiceOverride` when set; unchanged behavior when nil.
- **Quick Test (both platforms)** — prefers `voiceOverride`, falls back to the existing `entry.model.id` convention.
- **Config schema** — `models.<id>.voiceOverride` readable/writable on both platforms, so it can be set via config without new UI.

`nil` = exactly today's behavior. This unblocks TTS-provider voice selection (fish, custom voice ids) entirely in-config — no proxy, no code changes per vendor.

## Test plan (manual)

1. Add an OpenAI-compatible provider pointed at any TTS endpoint with a custom voice id (e.g. fish compat).
2. Add a model entry; `models.<id>.voiceOverride = <voice id>`.
3. Quick Test → audio uses `<voice id>`.
4. Read-aloud with the entry in the Voice Output group → same voice.
5. Unset → provider default (regression check).
