### PR TITLE
iOS: add native Bot teams, GPT-6 OAuth discovery, and App Group fallback

### DIFF
--- a/scripts/test_codex_oauth.sh
+++ b/scripts/test_codex_oauth.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Runs the actual Foundation-only production helpers without booting iOS.
+set -euo pipefail
+task_repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+task_test_dir="$(mktemp -d)"
+trap 'rm -rf "$task_test_dir"' EXIT
+mkdir -p "$task_test_dir/Sources/CodexOAuthLogic" "$task_test_dir/Tests/CodexOAuthLogicTests"
+cp "$task_repo_root/src/ios/Providers/OpenAI/OAuth/CodexOAuthToken.swift" "$task_test_dir/Sources/CodexOAuthLogic/"
+cp "$task_repo_root/src/ios/Providers/OpenAI/OAuth/CodexModelCatalog.swift" "$task_test_dir/Sources/CodexOAuthLogic/"
+cat > "$task_test_dir/Package.swift" <<'SWIFT'
+// swift-tools-version: 5.9
+import PackageDescription
+let package = Package(name: "CodexOAuthLogic", targets: [
+    .target(name: "CodexOAuthLogic"),
+    .testTarget(name: "CodexOAuthLogicTests", dependencies: ["CodexOAuthLogic"]),
+])
+SWIFT
+{
+    echo '@testable import CodexOAuthLogic'
+    cat "$task_repo_root/src/ios/MinisTests/CodexOAuthTests.swift"
+} > "$task_test_dir/Tests/CodexOAuthLogicTests/CodexOAuthTests.swift"
+swift test --package-path "$task_test_dir"

--- a/src/ios/Agent/Chat/AIChatViewModel+ConcurrentTools.swift
+++ b/src/ios/Agent/Chat/AIChatViewModel+ConcurrentTools.swift
@@ -799,6 +799,21 @@ extension AIChatViewModel {
             toolOutput = memResult.output
             toolSuccess = memResult.success
 
+        case "team_list", "team_create", "team_dispatch", "team_status", "team_cancel":
+            // Keep team actions inside the existing preflight, cancellation,
+            // loop-detection and snapshot pipeline. Do not execute a task by
+            // waiting on the shared iSH shell.
+            let teamResult = await executeTeamTool(
+                name: tu.name, args: toolArgs,
+                toolCallID: tu.id,
+                argumentsWereTruncated: truncationRepairTag != nil
+            )
+            toolOutput = teamResult.output
+            toolSuccess = teamResult.success
+            if msgIdx < messages.count, blockIdx < messages[msgIdx].blocks.count {
+                messages[msgIdx].blocks[blockIdx].content = toolOutput
+            }
+
         default:
             toolOutput = "Error: Unknown tool '\(tu.name)'"
             toolSuccess = false

--- a/src/ios/Agent/Chat/AIChatViewModel+Persistence.swift
+++ b/src/ios/Agent/Chat/AIChatViewModel+Persistence.swift
@@ -134,7 +134,7 @@ extension AIChatViewModel {
 
     /// For UI, we merge consecutive assistant + tool-result turns into a single ChatMessage,
     /// matching how they appeared during the live session.
-    func loadSession() async {
+    func loadSession(activateSession: Bool = true) async {
         guard let sessionId else { return }
 
         let sinceAppear = (CFAbsoluteTimeGetCurrent() - Self.onAppearTimestamp) * 1000
@@ -169,12 +169,12 @@ extension AIChatViewModel {
         let stack = Thread.callStackSymbols.prefix(10).joined(separator: " | ")
         logger.info("[ReloadTrace] loadSession() → spinner ON sid=\(sessionId.prefix(8)) callerStack=\(stack)")
 
-        Self.activeSessionId = sessionId
+        if activateSession { Self.activeSessionId = sessionId }
         // [T-ios-session-unread-badge] Opening the session reads its new message,
         // so clear the transient red "unread" dot. Only `.unread` is removed; the
         // `.paused` entry (a different concern) is left to its canResume-driven
         // lifecycle below.
-        SessionBadgeStore.shared.remove(.unread, for: sessionId)
+        if activateSession { SessionBadgeStore.shared.remove(.unread, for: sessionId) }
         // [T-session-paused-badge-active-false-positive] No clear-on-open here:
         // merely opening an interrupted session doesn't resolve it. The PAUSED
         // badge is driven by `canResume` (AIChatViewModel's canResume didSet) —
@@ -631,7 +631,9 @@ extension AIChatViewModel {
         // badge baseline to the current assistant-turn count. Without this, a
         // late/duplicate endBackgroundProcessing() after read (baseline still
         // at its -1 init) would see turns > -1 and re-badge with no new content.
-        lastBadgedAssistantTurnCount = loadedHistory.reduce(0) { $0 + ($1.role == .assistant ? 1 : 0) }
+        if activateSession {
+            lastBadgedAssistantTurnCount = loadedHistory.reduce(0) { $0 + ($1.role == .assistant ? 1 : 0) }
+        }
 
         let phase25Elapsed = (CFAbsoluteTimeGetCurrent() - phase2aStart) * 1000 - phase2aElapsed
         let phase2sigStart = CFAbsoluteTimeGetCurrent()
@@ -1012,7 +1014,7 @@ extension AIChatViewModel {
 
     /// Creates a session if needed and returns its ID.
     @discardableResult
-    func ensureSessionReturningId() async -> String {
+    func ensureSessionReturningId(activateSession: Bool = true) async -> String {
         if let sid = sessionId {
             logger.info("🔑DRAFT [vm=\(self.vmInstanceId)] ensureSession already has sessionId=\(sid)")
             return sid
@@ -1020,7 +1022,7 @@ extension AIChatViewModel {
         let model = selectedModel
         let session = await ChatStore.shared.createSession(modelId: model.id, source: sessionSource)
         sessionId = session.id
-        Self.activeSessionId = session.id
+        if activateSession { Self.activeSessionId = session.id }
         // [T-memory-enabled-new-session-bug] Sync the @Published memoryEnabled
         // to the value createSession just persisted from the global default.
         // A draft VM initializes memoryEnabled = true and never runs

--- a/src/ios/Agent/Chat/AIChatViewModel+RequestBudget.swift
+++ b/src/ios/Agent/Chat/AIChatViewModel+RequestBudget.swift
@@ -253,23 +253,31 @@ extension AIChatViewModel {
             .appendingPathComponent("browser", isDirectory: true)
     }
 
-    /// App Group container root for FileProvider-visible directories.
+    /// Resolve storage once per process so a local fallback never changes
+    /// halfway through a run. This does not grant access to another App Group
+    /// or make the private directory visible to extensions.
+    nonisolated private static let minisStorageContainerRoot: URL = {
+        if let shared = SharedContainerStore.containerURL { return shared }
+        let library = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+        return library.appendingPathComponent("MinisLocalStorage", isDirectory: true)
+    }()
+
+    /// App Group container root for FileProvider-visible directories, or
+    /// app-private storage when the signing profile cannot access that group.
     /// Everything under this path is exposed to iOS Files via the replicated
     /// FileProvider extension. Keep ONLY user-facing subdirs (shared, skills,
     /// memory) here — anything else leaks into "On My iPhone → Minis".
     nonisolated static var minisAppGroupRoot: URL {
-        FileManager.default.containerURL(
-            forSecurityApplicationGroupIdentifier: SharedContainerStore.appGroupID
-        )!.appendingPathComponent("MinisFileProvider", isDirectory: true)
+        let url = minisStorageContainerRoot.appendingPathComponent("MinisFileProvider", isDirectory: true)
+        try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
     }
 
     /// App Group subdirectory for private metadata that must NOT be exposed
     /// to iOS Files (mounted-folders.json, FileProvider extension logs, etc).
     /// Sibling of `minisAppGroupRoot` inside the same App Group container.
     nonisolated static var minisConfigRoot: URL {
-        let url = FileManager.default.containerURL(
-            forSecurityApplicationGroupIdentifier: SharedContainerStore.appGroupID
-        )!.appendingPathComponent("MinisConfig", isDirectory: true)
+        let url = minisStorageContainerRoot.appendingPathComponent("MinisConfig", isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
     }

--- a/src/ios/Agent/Chat/AIChatViewModel+TeamTools.swift
+++ b/src/ios/Agent/Chat/AIChatViewModel+TeamTools.swift
@@ -1,0 +1,249 @@
+import Foundation
+
+// Native team tools for Minis. Each Bot uses its own chat session; task
+// scheduling and persistence belong to MinisTeamStore, not to the tool loop.
+extension AIChatViewModel {
+    struct TeamToolResult {
+        let output: String
+        let success: Bool
+    }
+
+    private var isTeamBotSession: Bool {
+        guard let sessionId else { return false }
+        let store = MinisTeamStore.shared
+        return store.bots.contains { $0.sessionID == sessionId }
+            || store.tasks.contains { $0.sessionID == sessionId }
+    }
+
+    func makeTeamTools() -> [AgentToolDefinition] {
+        let title = AgentToolParam(
+            type: .string,
+            description: "A concise summary of this action, in the user's language."
+        )
+        var tools = [
+            AgentToolDefinition(
+                name: "team_list",
+                description: "List the user's saved Bots and recent task states. Bots have separate chat histories and can have different roles/models. They share this device's Linux filesystem and, when enabled for a session, device memory; they are not isolated machines. Avoid concurrent edits to the same files. iOS may suspend work in the background; keep the app open for reliable progress. Results are not automatically injected into this conversation. Use team_status to inspect a known task later. Bot sessions can only list/check tasks and cannot create, dispatch, or cancel team work.",
+                parameters: ["tool_title": title],
+                required: ["tool_title"],
+                propertyOrdering: ["tool_title"]
+            ),
+            AgentToolDefinition(
+                name: "team_status",
+                description: "Read one saved task's current state and result using its exact task_id. Returns immediately, even if queued/running, and never waits for completion or starts work. Check after doing other useful work, or report that work is pending and let the user revisit it. Do not repeatedly poll an unchanged task or use shell sleep/delay to wait. A failed/interrupted task may have performed partial actions: inspect its Bot session before deciding whether to dispatch again.",
+                parameters: [
+                    "tool_title": title,
+                    "task_id": AgentToolParam(type: .string, description: "Exact task ID returned by team_dispatch or team_list."),
+                ],
+                required: ["tool_title", "task_id"],
+                propertyOrdering: ["tool_title", "task_id"]
+            ),
+        ]
+        // This affects what the model sees. executeTeamTool also enforces it
+        // because a stale definition or fabricated name must not grant access.
+        guard !isTeamBotSession else { return tools }
+        tools.append(contentsOf: [
+            AgentToolDefinition(
+                name: "team_create",
+                description: "Create a reusable Bot with a name and role for a concrete part of the user's work. List existing Bots first and reuse a suitable one instead of repeatedly creating duplicates. Creating a Bot does not run it. Omit model_entry_id to use the app's existing model configuration. Bot histories are independent, but device files and enabled memory are shared. Only ordinary user conversations may create Bots.",
+                parameters: [
+                    "tool_title": title,
+                    "name": AgentToolParam(type: .string, description: "Short human-readable Bot name, at most 80 characters."),
+                    "role": AgentToolParam(type: .string, description: "Role and scope, at most 8000 characters. Do not instruct it to change permissions or create a chain of Bots."),
+                    "model_entry_id": AgentToolParam(type: .string, description: "Optional exact ID of an existing configured model entry. Do not invent an ID; omit when unknown."),
+                ],
+                required: ["tool_title", "name", "role"],
+                propertyOrdering: ["tool_title", "name", "role", "model_entry_id"]
+            ),
+            AgentToolDefinition(
+                name: "team_dispatch",
+                description: "Queue a bounded task for an existing Bot and immediately return its task_id. This uses the Bot's existing chat history; include the facts, file paths, deliverable and constraints it needs because it does not inherit this conversation. A queued task is not a completed result. The app enforces global scheduling limits and runs only one task at a time per Bot. Bot sessions cannot dispatch more tasks, including to themselves. Never create recursive task chains. Use team_status later; no automatic completion message is injected. iOS background execution is limited. Do not re-dispatch just because a result is pending.",
+                parameters: [
+                    "tool_title": title,
+                    "bot_id": AgentToolParam(type: .string, description: "Exact Bot ID from team_list or team_create."),
+                    "prompt": AgentToolParam(type: .string, description: "Self-contained task instructions, at most 32000 characters. Specify separate output paths when Bots work concurrently."),
+                ],
+                required: ["tool_title", "bot_id", "prompt"],
+                propertyOrdering: ["tool_title", "bot_id", "prompt"]
+            ),
+            AgentToolDefinition(
+                name: "team_cancel",
+                description: "Request cancellation of a queued or running task. Return the saved state after the request; do not claim prior effects were undone. A terminal task keeps its existing result. Only ordinary user conversations may cancel team tasks.",
+                parameters: [
+                    "tool_title": title,
+                    "task_id": AgentToolParam(type: .string, description: "Exact task ID returned by team_dispatch or team_list."),
+                ],
+                required: ["tool_title", "task_id"],
+                propertyOrdering: ["tool_title", "task_id"]
+            ),
+        ])
+        return tools
+    }
+
+    func executeTeamTool(
+        name: String,
+        args: [String: Any],
+        toolCallID: String? = nil,
+        argumentsWereTruncated: Bool = false
+    ) async -> TeamToolResult {
+        do {
+            try Task.checkCancellation()
+            guard !userDidCancel else { throw CancellationError() }
+            let store = MinisTeamStore.shared
+            let readOnly = name == "team_list" || name == "team_status"
+            if !readOnly {
+                guard !argumentsWereTruncated else {
+                    throw MinisTeamError.invalidInput("Team action was not executed because its arguments were truncated in transit. Reissue a complete, shorter request.")
+                }
+                guard !isTeamBotSession else {
+                    throw MinisTeamError.recursiveDispatch
+                }
+                guard let sessionId, !sessionId.isEmpty else {
+                    throw MinisTeamError.invalidInput("Create or open a conversation before changing team tasks.")
+                }
+            }
+
+            var payload: [String: Any]
+            switch name {
+            case "team_list":
+                let latest = store.tasks.sorted { $0.createdAt > $1.createdAt }.prefix(20)
+                payload = [
+                    "bots": store.bots.map(Self.teamBotPayload),
+                    "recent_tasks": latest.map { Self.teamTaskPayload($0, includeResult: false) },
+                    "total_tasks": store.tasks.count,
+                    "can_manage_team": !isTeamBotSession && sessionId != nil,
+                    "execution_note": "Independent Bot histories; shared device filesystem and enabled memory. Keep the app open. Results require team_status or the team screen; no automatic message is sent here.",
+                ]
+            case "team_create":
+                let botName = try Self.teamString("name", in: args, limit: 80)
+                let role = try Self.teamString("role", in: args, limit: 8000)
+                let entryID = try Self.teamOptionalString("model_entry_id", in: args, limit: 200)
+                payload = Self.teamBotPayload(try store.createBot(name: botName, role: role, modelEntryID: entryID))
+            case "team_dispatch":
+                let botID = try Self.teamString("bot_id", in: args, limit: 200)
+                let prompt = try Self.teamString("prompt", in: args, limit: 32000)
+                if let bot = store.bot(id: botID),
+                   let botSessionID = bot.sessionID, botSessionID == sessionId {
+                    throw MinisTeamError.recursiveDispatch
+                }
+                // The provider's tool-call identity stays outside model
+                // arguments. Store persistence makes replaying the same call
+                // return its original task instead of repeating side effects.
+                let task = try store.dispatch(
+                    botID: botID, prompt: prompt,
+                    sourceSessionID: sessionId, requestID: toolCallID
+                )
+                payload = Self.teamTaskPayload(task, includeResult: task.state.isTerminal)
+                if payload["content_locked"] as? Bool != true {
+                    payload["execution_note"] = task.state.isTerminal
+                        ? "This task already has a terminal saved state. No new task was queued. Its recorded result/error is included; inspect partial effects before retrying failed or interrupted work."
+                        : "Task is queued or running, not completed. Do other work or report it pending. Check team_status later; do not wait in the shell or repeatedly poll."
+                }
+            case "team_status":
+                let taskID = try Self.teamString("task_id", in: args, limit: 200)
+                guard let task = store.task(id: taskID) else {
+                    throw MinisTeamError.invalidInput("Task not found. Use team_list to find an existing task ID.")
+                }
+                payload = Self.teamTaskPayload(task, includeResult: true)
+            case "team_cancel":
+                let taskID = try Self.teamString("task_id", in: args, limit: 200)
+                guard store.task(id: taskID) != nil else {
+                    throw MinisTeamError.invalidInput("Task not found. Use team_list to find an existing task ID.")
+                }
+                await store.cancel(taskID: taskID)
+                guard let task = store.task(id: taskID) else {
+                    throw MinisTeamError.invalidInput("The task is no longer available. Check the team screen.")
+                }
+                payload = Self.teamTaskPayload(task, includeResult: true)
+                if payload["content_locked"] as? Bool != true {
+                    payload["execution_note"] = "This is the saved state after the cancellation request. Previously performed actions are not undone."
+                }
+            default:
+                throw MinisTeamError.invalidInput("Unknown team tool.")
+            }
+            if let storageError = store.storageError {
+                // Read-only inspection remains available even when the store
+                // reports an error. Do not hide a failed persistence operation.
+                payload["storage_error"] = storageError
+            }
+            let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys, .prettyPrinted])
+            return TeamToolResult(
+                output: String(decoding: data, as: UTF8.self),
+                success: readOnly || store.storageError == nil
+            )
+        } catch is CancellationError {
+            return TeamToolResult(output: "Team action cancelled before completion. Check saved task state before retrying.", success: false)
+        } catch {
+            return TeamToolResult(output: "Error: \(error.localizedDescription)", success: false)
+        }
+    }
+
+    private static func teamString(_ key: String, in args: [String: Any], limit: Int) throws -> String {
+        guard let value = args[key] as? String else {
+            throw MinisTeamError.invalidInput("'\(key)' must be a non-empty string.")
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.count <= limit else {
+            throw MinisTeamError.invalidInput("'\(key)' must contain 1–\(limit) characters.")
+        }
+        return trimmed
+    }
+
+    private static func teamOptionalString(_ key: String, in args: [String: Any], limit: Int) throws -> String? {
+        guard let raw = args[key], !(raw is NSNull) else { return nil }
+        if let value = raw as? String, value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return nil
+        }
+        return try teamString(key, in: args, limit: limit)
+    }
+
+    private static func teamBotPayload(_ bot: MinisBotProfile) -> [String: Any] {
+        // Read the current native lock state at serialization time. Team
+        // profiles must not expose a locked conversation's title or role.
+        if let sessionID = bot.sessionID,
+           SessionLockStore.shared.isVisuallyLocked(sessionID) {
+            return [
+                "bot_id": bot.id,
+                "content_locked": true,
+                "execution_note": "Bot details are locked. Open and unlock its conversation in the chat list before viewing this content.",
+            ]
+        }
+        var payload: [String: Any] = ["bot_id": bot.id, "name": bot.name, "role": bot.role]
+        payload["model_entry_id"] = bot.modelEntryID
+        payload["session_id"] = bot.sessionID
+        return payload
+    }
+
+    private static func teamTaskPayload(_ task: MinisTeamTask, includeResult: Bool) -> [String: Any] {
+        // Task records duplicate chat content. Apply the same live lock gate
+        // to both the Bot conversation and the originating user conversation,
+        // including status, cancellation and idempotent-dispatch responses.
+        if MinisTeamStore.shared.isTaskContentLocked(task) {
+            return [
+                "task_id": task.id,
+                "bot_id": task.botID,
+                "state": task.state.rawValue,
+                "content_locked": true,
+                "execution_note": "Task content is locked. Open and unlock the related Bot and source conversations in the chat list before viewing its details.",
+            ]
+        }
+        var payload: [String: Any] = [
+            "task_id": task.id,
+            "bot_id": task.botID,
+            "state": task.state.rawValue,
+            "created_at": task.createdAt.timeIntervalSince1970,
+            "updated_at": task.updatedAt.timeIntervalSince1970,
+        ]
+        payload["source_session_id"] = task.sourceSessionID
+        payload["session_id"] = task.sessionID
+        if includeResult {
+            payload["prompt"] = task.prompt
+            payload["result"] = task.result
+            payload["error"] = task.error
+        }
+        if task.state == .queued || task.state == .running {
+            payload["execution_note"] = "Work is pending. This call does not wait or guarantee background progress. Check later without a tight polling loop."
+        }
+        return payload
+    }
+}

--- a/src/ios/Agent/Chat/AIChatViewModel+ToolDefinitions.swift
+++ b/src/ios/Agent/Chat/AIChatViewModel+ToolDefinitions.swift
@@ -202,6 +202,7 @@ extension AIChatViewModel {
             ))
         }
 
+        tools.append(contentsOf: makeTeamTools())
         return tools
     }
 

--- a/src/ios/Agent/Team/MinisTeamModels.swift
+++ b/src/ios/Agent/Team/MinisTeamModels.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+struct MinisBotProfile: Identifiable, Codable, Equatable {
+    let id: String
+    var name: String
+    var role: String
+    var modelEntryID: String?
+    var sessionID: String?
+    let createdAt: Date
+    var updatedAt: Date
+}
+
+enum MinisTeamTaskState: String, Codable, CaseIterable {
+    case queued, running, completed, failed, cancelled, interrupted
+
+    var isTerminal: Bool {
+        switch self {
+        case .queued, .running: return false
+        case .completed, .failed, .cancelled, .interrupted: return true
+        }
+    }
+}
+
+struct MinisTeamTask: Identifiable, Codable, Equatable {
+    let id: String
+    let botID: String
+    let prompt: String
+    let sourceSessionID: String?
+    var sessionID: String?
+    var state: MinisTeamTaskState
+    var result: String?
+    var error: String?
+    let createdAt: Date
+    var updatedAt: Date
+    var startedAt: Date?
+    var finishedAt: Date?
+    var requestID: String? = nil
+}
+
+/// Scheduling operates on values so concurrency and crash recovery can be
+/// checked without starting an iSH kernel or making a model request.
+enum MinisTeamSchedulingPolicy {
+    static let maximumConcurrentTasks = 3
+
+    static func runnableTaskIDs(
+        tasks: [MinisTeamTask],
+        occupiedTaskIDs: Set<String> = [],
+        occupiedBotIDs: Set<String> = []
+    ) -> [String] {
+        let running = tasks.filter { $0.state == .running }
+        let occupied = occupiedTaskIDs.union(running.map(\.id))
+        var slots = max(0, maximumConcurrentTasks - occupied.count)
+        var busyBots = occupiedBotIDs.union(running.map(\.botID))
+        var selected: [String] = []
+        for task in tasks where task.state == .queued {
+            guard slots > 0 else { break }
+            guard !busyBots.contains(task.botID) else { continue }
+            selected.append(task.id)
+            busyBots.insert(task.botID)
+            slots -= 1
+        }
+        return selected
+    }
+
+    /// A process restart cannot prove whether a queued write or a dispatched
+    /// model call reached the other side. Never automatically send it again.
+    static func recovering(_ tasks: [MinisTeamTask], at now: Date) -> [MinisTeamTask] {
+        tasks.map { original in
+            guard !original.state.isTerminal else { return original }
+            var task = original
+            task.state = .interrupted
+            task.error = "应用已重新启动，无法确认任务是否完成。请查看 Bot 会话，确认后再手动派发新任务。"
+            task.updatedAt = now
+            task.finishedAt = now
+            return task
+        }
+    }
+}
+
+enum MinisTeamError: LocalizedError {
+    case invalidInput(String)
+    case botNotFound
+    case botBusy
+    case recursiveDispatch
+    case unavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidInput(let detail), .unavailable(let detail): return detail
+        case .botNotFound: return "找不到这个 Bot。"
+        case .botBusy: return "这个 Bot 还有排队或运行中的任务，请先取消或等待完成。"
+        case .recursiveDispatch: return "Bot 任务不能继续派发 Bot 任务。请由主会话或团队页面派发。"
+        }
+    }
+}

--- a/src/ios/Agent/Team/MinisTeamStore.swift
+++ b/src/ios/Agent/Team/MinisTeamStore.swift
@@ -1,0 +1,406 @@
+import Foundation
+import Combine
+
+/// A small scheduler over ordinary Minis conversations. Bots retain the same
+/// tools, permissions, memory settings and iOS lifecycle limits as those chats.
+/// Results are explicitly read by task ID; nothing is injected into another
+/// conversation and no synchronous iSH bridge is called from the main actor.
+@MainActor
+final class MinisTeamStore: ObservableObject {
+    static let shared = MinisTeamStore()
+
+    @Published private(set) var bots: [MinisBotProfile] = []
+    @Published private(set) var tasks: [MinisTeamTask] = []
+    @Published private(set) var storageError: String?
+
+    private struct Document: Codable {
+        var version = 1
+        var bots: [MinisBotProfile]
+        var tasks: [MinisTeamTask]
+    }
+
+    private struct LiveRun {
+        let botID: String
+        let vm: AIChatViewModel
+        let userMessageID: UUID
+        let nativeTask: Task<Void, Never>
+        var finished = false
+    }
+
+    private let fileURL: URL
+    private let automaticPolling: Bool
+    private var storageBlocked = false
+    private var liveRuns: [String: LiveRun] = [:]
+    // A cancelled queued task must stay vetoed even when writing the terminal
+    // state fails and an unrelated successful write later clears storageError.
+    private var pendingCancellationIDs: Set<String> = []
+    private var pollingTask: Task<Void, Never>?
+    private var refreshing = false
+
+    /// The alternate location is useful for storage/recovery tests. Loading
+    /// never creates conversations, boots Linux, or makes a model request.
+    init(fileURL: URL? = nil, automaticPolling: Bool = true) {
+        self.automaticPolling = automaticPolling
+        self.fileURL = fileURL ?? FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("MinisTeam", isDirectory: true)
+            .appendingPathComponent("team.json")
+        load()
+    }
+
+    func bot(id: String) -> MinisBotProfile? { bots.first { $0.id == id } }
+    func task(id: String) -> MinisTeamTask? { tasks.first { $0.id == id } }
+
+    /// Callers rendering or returning stored task content must preserve the
+    /// conversation lock even after a task has finished or its Bot was deleted.
+    func isTaskContentLocked(_ task: MinisTeamTask) -> Bool {
+        [task.sessionID, task.sourceSessionID].compactMap { $0 }.contains {
+            SessionLockStore.shared.isVisuallyLocked($0)
+        }
+    }
+
+    @discardableResult
+    func createBot(name: String, role: String, modelEntryID: String? = nil) throws -> MinisBotProfile {
+        let fields = try validatedProfile(name: name, role: role, modelEntryID: modelEntryID)
+        guard bots.count < 64 else { throw MinisTeamError.invalidInput("最多保留 64 个 Bot。") }
+        let now = Date()
+        let profile = MinisBotProfile(id: UUID().uuidString, name: fields.name, role: fields.role,
+                                     modelEntryID: fields.model, sessionID: nil, createdAt: now, updatedAt: now)
+        try commit(bots: bots + [profile], tasks: tasks)
+        return profile
+    }
+
+    func updateBot(id: String, name: String, role: String, modelEntryID: String?) throws {
+        guard let index = bots.firstIndex(where: { $0.id == id }) else { throw MinisTeamError.botNotFound }
+        try requireIdleBot(id)
+        let fields = try validatedProfile(name: name, role: role, modelEntryID: modelEntryID)
+        var updated = bots
+        updated[index].name = fields.name
+        updated[index].role = fields.role
+        updated[index].modelEntryID = fields.model
+        updated[index].updatedAt = Date()
+        try commit(bots: updated, tasks: tasks)
+    }
+
+    /// Removing a profile deliberately retains its ordinary chat and task
+    /// history. This operation never deletes a user's conversation or files.
+    func deleteBot(id: String) throws {
+        guard bot(id: id) != nil else { throw MinisTeamError.botNotFound }
+        try requireIdleBot(id)
+        try commit(bots: bots.filter { $0.id != id }, tasks: tasks)
+    }
+
+    @discardableResult
+    func dispatch(botID: String, prompt: String, sourceSessionID: String? = nil, requestID: String? = nil) throws -> MinisTeamTask {
+        let text = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, text.count <= 40_000 else {
+            throw MinisTeamError.invalidInput("任务内容须为 1 到 40000 个字符。")
+        }
+        if let requestID {
+            guard !requestID.isEmpty, requestID.count <= 512 else {
+                throw MinisTeamError.invalidInput("派发请求标识无效。")
+            }
+            if let existing = tasks.first(where: { $0.requestID == requestID && $0.sourceSessionID == sourceSessionID }) {
+                guard existing.botID == botID, existing.prompt == text else {
+                    throw MinisTeamError.invalidInput("同一请求标识不能用于不同的 Bot 或任务内容。")
+                }
+                return existing
+            }
+        }
+        guard let profile = bot(id: botID) else { throw MinisTeamError.botNotFound }
+        if let source = sourceSessionID,
+           bots.contains(where: { $0.sessionID == source }) || tasks.contains(where: { $0.sessionID == source }) {
+            throw MinisTeamError.recursiveDispatch
+        }
+        guard tasks.filter({ !$0.state.isTerminal }).count < 100 else {
+            throw MinisTeamError.invalidInput("队列已有 100 个未完成任务，请先等待或取消。")
+        }
+        let now = Date()
+        let queued = MinisTeamTask(id: UUID().uuidString, botID: botID, prompt: text,
+                                   sourceSessionID: sourceSessionID, sessionID: profile.sessionID,
+                                   state: .queued, result: nil, error: nil, createdAt: now,
+                                   updatedAt: now, startedAt: nil, finishedAt: nil, requestID: requestID)
+        // Durably enqueue before scheduling any external side effect.
+        try commit(bots: bots, tasks: tasks + [queued])
+        ensurePolling()
+        return queued
+    }
+
+    /// Refresh returns after dispatching available work, not after model calls
+    /// finish. Serial actor admission plus retained native Task handles prevents
+    /// overlap, including the period while a cancelled task is cleaning up.
+    func refresh() async {
+        guard !refreshing, !storageBlocked else { return }
+        refreshing = true
+        defer { refreshing = false }
+
+        if storageError != nil {
+            // A transient full-disk/unavailable-directory failure may recover.
+            // Persist the exact current state before allowing another send.
+            do { try commit(bots: bots, tasks: tasks) }
+            catch { return }
+        }
+
+        for id in Array(pendingCancellationIDs) {
+            endTask(id, state: .cancelled, error: "任务已取消。")
+            if task(id: id)?.state.isTerminal != false { pendingCancellationIDs.remove(id) }
+        }
+
+        for id in Array(liveRuns.keys) where liveRuns[id]?.finished == true {
+            finishRun(id)
+        }
+        guard storageError == nil else { return }
+
+        var deferredBots = Set<String>()
+        while true {
+            let runnable = MinisTeamSchedulingPolicy.runnableTaskIDs(
+                tasks: tasks.filter { !pendingCancellationIDs.contains($0.id) },
+                occupiedTaskIDs: Set(liveRuns.keys),
+                occupiedBotIDs: Set(liveRuns.values.map(\.botID)).union(deferredBots)
+            )
+            guard let id = runnable.first, let queued = task(id: id) else { break }
+            do {
+                if !(try await startTask(id)) { deferredBots.insert(queued.botID) }
+            } catch {
+                endTask(id, state: .failed, error: error.localizedDescription)
+            }
+            if storageError != nil { break }
+        }
+    }
+
+    func cancel(taskID: String) async {
+        guard let existing = task(id: taskID), !existing.state.isTerminal else { return }
+        pendingCancellationIDs.insert(taskID)
+        // Cancellation is always honoured even if the local disk is full.
+        // Retain the captured native task until its completion callback, since
+        // vm.cancel() sets isProcessing=false before its cleanup has finished.
+        if let run = liveRuns[taskID] {
+            // The native send task also drains manual follow-ups. Once such a
+            // message has started, stopping its VM would cancel the user's new
+            // work rather than just the original team task.
+            if let boundary = run.vm.messages.firstIndex(where: { $0.id == run.userMessageID }) {
+                let manualTurnStarted = run.vm.messages.dropFirst(boundary + 1).contains {
+                    $0.role == .user && !$0.isQueued
+                }
+                if !manualTurnStarted { run.vm.cancel() }
+            }
+        }
+        endTask(taskID, state: .cancelled, error: "任务已取消。")
+        if task(id: taskID)?.state.isTerminal == true { pendingCancellationIDs.remove(taskID) }
+        ensurePolling()
+    }
+
+    private func startTask(_ id: String) async throws -> Bool {
+        guard let queued = task(id: id), queued.state == .queued else { return true }
+        guard let profile = bot(id: queued.botID) else { throw MinisTeamError.botNotFound }
+        let vm: AIChatViewModel
+        let sid: String
+        if let existingID = profile.sessionID {
+            if SessionActivityTracker.shared.isActive(existingID) { return false }
+            guard !SessionLockStore.shared.isVisuallyLocked(existingID) else {
+                throw MinisTeamError.unavailable("请先在聊天列表解锁这个 Bot 的会话。")
+            }
+            guard let session = await ChatStore.shared.getSession(existingID), !session.isRemote else {
+                throw MinisTeamError.unavailable("Bot 会话已不存在或为只读远端会话，请创建新 Bot。")
+            }
+            let cached = ViewModelCache.shared.getOrCreate(for: existingID)
+            vm = cached.vm
+            if cached.isNew { await vm.loadSession(activateSession: false) }
+            sid = existingID
+        } else {
+            vm = ViewModelCache.shared.createDraft()
+            vm.sessionSource = "team"
+            sid = await vm.ensureSessionReturningId(activateSession: false)
+            // Preserve the fixed conversation even if cancellation happened
+            // during creation. Never recreate it on a later queued task.
+            guard let index = bots.firstIndex(where: { $0.id == profile.id }) else { return true }
+            var updatedBots = bots
+            updatedBots[index].sessionID = sid
+            updatedBots[index].updatedAt = Date()
+            var updatedTasks = tasks
+            for index in updatedTasks.indices where updatedTasks[index].botID == profile.id && !updatedTasks[index].state.isTerminal {
+                updatedTasks[index].sessionID = sid
+            }
+            try commit(bots: updatedBots, tasks: updatedTasks)
+            await ChatStore.shared.updateSessionTitle(sid, title: profile.name)
+        }
+
+        // Actor calls above may have admitted cancellation or a manual send.
+        guard task(id: id)?.state == .queued, !pendingCancellationIDs.contains(id) else { return true }
+        guard !vm.isProcessing, !vm.isCompacting, !SessionActivityTracker.shared.isActive(sid),
+              vm.promptQueue.isEmpty else { return false }
+        guard vm.inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              vm.attachments.isEmpty, vm.editingMessageIndex == nil else { return false }
+        guard !SessionLockStore.shared.isVisuallyLocked(sid) else {
+            throw MinisTeamError.unavailable("请先解锁 Bot 会话。")
+        }
+        // Keep the existing context/permission policy. A hidden team task must
+        // not enable automatic compaction or dismiss a user's pending prompt.
+        guard !vm.showCompactBeforeSendPrompt, !vm.showContextExhaustedPrompt else {
+            throw MinisTeamError.unavailable("Bot 会话正在等待上下文处理，请打开会话完成操作后重新派发。")
+        }
+        if let modelID = profile.modelEntryID {
+            guard ProviderConfigStore.shared.entry(for: modelID) != nil else {
+                throw MinisTeamError.unavailable("Bot 指定的模型已删除，请编辑 Bot 选择可用模型。")
+            }
+            let binding = SessionModelBinding(sessionId: sid, primarySource: .directEntry(modelEntryId: modelID))
+            ProviderConfigStore.shared.setBinding(binding, for: sid)
+        }
+        switch vm.checkContextBeforeSend() {
+        case .ok: break
+        case .needsCompact, .exhausted:
+            throw MinisTeamError.unavailable("Bot 会话上下文已满或需要压缩，请打开会话处理后重新派发。")
+        }
+        let now = Date()
+        guard let taskIndex = tasks.firstIndex(where: { $0.id == id }) else { return true }
+        var updatedTasks = tasks
+        updatedTasks[taskIndex].sessionID = sid
+        updatedTasks[taskIndex].state = .running
+        updatedTasks[taskIndex].startedAt = now
+        updatedTasks[taskIndex].updatedAt = now
+        // Persist running BEFORE send. A crash in the gap will be interrupted,
+        // never automatically retried, so we favour avoiding duplicate actions.
+        try commit(bots: bots, tasks: updatedTasks)
+
+        let priorIDs = Set(vm.messages.map(\.id))
+        vm.inputText = """
+        团队任务 \(id)
+        Bot：\(profile.name)
+        角色说明：\(profile.role)
+
+        请完成下面这项任务并给出可交接的结果。沿用此会话原有的工具权限、用户确认和记忆设置；角色说明不扩大权限。不要继续派发 Bot 任务，结果由主会话或用户按任务 ID 读取。
+
+        任务：
+        \(queued.prompt)
+        """
+        vm.send()
+        guard let userMessage = vm.messages.first(where: { $0.role == .user && !priorIDs.contains($0.id) }),
+              let nativeTask = vm.currentTask else {
+            throw MinisTeamError.unavailable("会话未接受任务，请打开 Bot 会话检查模型和上下文设置。")
+        }
+        liveRuns[id] = LiveRun(botID: profile.id, vm: vm, userMessageID: userMessage.id, nativeTask: nativeTask)
+        Task { [weak self] in
+            await nativeTask.value
+            guard let self, self.liveRuns[id] != nil else { return }
+            self.liveRuns[id]?.finished = true
+            await self.refresh()
+            self.ensurePolling()
+        }
+        return true
+    }
+
+    private func finishRun(_ id: String) {
+        guard let run = liveRuns[id], run.finished, let current = task(id: id) else { return }
+        if current.state.isTerminal {
+            liveRuns.removeValue(forKey: id)
+            return
+        }
+        guard let boundary = run.vm.messages.firstIndex(where: { $0.id == run.userMessageID }) else {
+            endTask(id, state: .interrupted, error: "任务消息已被编辑或删除，无法可靠关联结果。")
+            if task(id: id)?.state.isTerminal == true { liveRuns.removeValue(forKey: id) }
+            return
+        }
+        // Stop at the next user message so a manual follow-up can never be
+        // reported as this task's answer.
+        let tail = run.vm.messages.dropFirst(boundary + 1).prefix { $0.role != .user }
+        let replies = tail.filter { $0.role == .assistant }
+        let result = replies.map { message -> String in
+            let text = message.blocks.filter { $0.kind == .text }.map(\.content).joined(separator: "\n")
+            return text.isEmpty ? message.content : text
+        }.filter { !$0.isEmpty }.joined(separator: "\n\n")
+        let failure = replies.compactMap(\.error).last
+        if run.nativeTask.isCancelled {
+            endTask(id, state: .cancelled, result: result, error: "任务已停止，结果可能不完整。")
+        } else if let failure {
+            endTask(id, state: .failed, result: result, error: failure)
+        } else if replies.isEmpty || run.vm.canResume {
+            endTask(id, state: .interrupted, result: result, error: "任务未正常结束，请打开 Bot 会话查看详情。")
+        } else {
+            endTask(id, state: .completed, result: result)
+        }
+        if task(id: id)?.state.isTerminal == true { liveRuns.removeValue(forKey: id) }
+    }
+
+    private func endTask(_ id: String, state: MinisTeamTaskState, result: String? = nil, error: String? = nil) {
+        guard let index = tasks.firstIndex(where: { $0.id == id }), !tasks[index].state.isTerminal else { return }
+        var updated = tasks
+        updated[index].state = state
+        updated[index].result = result?.isEmpty == false ? result : nil
+        updated[index].error = error
+        updated[index].updatedAt = Date()
+        updated[index].finishedAt = updated[index].updatedAt
+        do { try commit(bots: bots, tasks: updated) }
+        catch { storageError = "保存任务状态失败：\(error.localizedDescription)" }
+    }
+
+    private func ensurePolling() {
+        guard automaticPolling, pollingTask == nil, !storageBlocked else { return }
+        pollingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await self.refresh()
+                if self.liveRuns.isEmpty && (!self.tasks.contains { !$0.state.isTerminal } || self.storageError != nil) {
+                    self.pollingTask = nil
+                    return
+                }
+                do { try await Task.sleep(nanoseconds: 2_000_000_000) }
+                catch { self.pollingTask = nil; return }
+            }
+        }
+    }
+
+    private func validatedProfile(name: String, role: String, modelEntryID: String?) throws -> (name: String, role: String, model: String?) {
+        let name = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let role = role.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !name.isEmpty, name.count <= 80 else { throw MinisTeamError.invalidInput("Bot 名称须为 1 到 80 个字符。") }
+        guard !role.isEmpty, role.count <= 8_000 else { throw MinisTeamError.invalidInput("角色说明须为 1 到 8000 个字符。") }
+        let model = modelEntryID?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let model, !model.isEmpty, ProviderConfigStore.shared.entry(for: model) == nil {
+            throw MinisTeamError.invalidInput("找不到所选模型，请重新选择。")
+        }
+        return (name, role, model?.isEmpty == false ? model : nil)
+    }
+
+    private func requireIdleBot(_ id: String) throws {
+        guard !tasks.contains(where: { $0.botID == id && !$0.state.isTerminal }),
+              !liveRuns.values.contains(where: { $0.botID == id }) else { throw MinisTeamError.botBusy }
+    }
+
+    private func load() {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return }
+        do {
+            let document = try JSONDecoder().decode(Document.self, from: Data(contentsOf: fileURL))
+            let sessionIDs = document.bots.compactMap(\.sessionID)
+            guard document.version == 1,
+                  Set(document.bots.map(\.id)).count == document.bots.count,
+                  Set(document.tasks.map(\.id)).count == document.tasks.count,
+                  Set(sessionIDs).count == sessionIDs.count else {
+                throw MinisTeamError.unavailable("团队文件版本或标识无效，原文件已保留。")
+            }
+            bots = document.bots
+            tasks = MinisTeamSchedulingPolicy.recovering(document.tasks, at: Date())
+            if tasks != document.tasks { try commit(bots: bots, tasks: tasks) }
+        } catch {
+            // Do not silently replace corrupt or temporarily unavailable data.
+            storageBlocked = true
+            storageError = "团队数据无法读取：\(error.localizedDescription)"
+        }
+    }
+
+    private func commit(bots nextBots: [MinisBotProfile], tasks nextTasks: [MinisTeamTask]) throws {
+        guard !storageBlocked else { throw MinisTeamError.unavailable(storageError ?? "团队存储不可用。") }
+        do {
+            let directory = fileURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.sortedKeys]
+            let data = try encoder.encode(Document(bots: nextBots, tasks: nextTasks))
+            try data.write(to: fileURL, options: .atomic)
+            bots = nextBots
+            tasks = nextTasks
+            storageError = nil
+        } catch {
+            storageError = error.localizedDescription
+            throw error
+        }
+    }
+}

--- a/src/ios/Agent/Team/StandaloneTests/Package.swift
+++ b/src/ios/Agent/Team/StandaloneTests/Package.swift
@@ -1,0 +1,12 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "MinisTeamHarness",
+    platforms: [.macOS(.v13)],
+    products: [.library(name: "TeamHarness", targets: ["TeamHarness"])],
+    targets: [
+        .target(name: "TeamHarness"),
+        .testTarget(name: "TeamHarnessTests", dependencies: ["TeamHarness"])
+    ]
+)

--- a/src/ios/Agent/Team/StandaloneTests/Sources/TeamHarness/PlatformStubs.swift
+++ b/src/ios/Agent/Team/StandaloneTests/Sources/TeamHarness/PlatformStubs.swift
@@ -1,0 +1,147 @@
+// Platform boundary substitutes only. The scheduler, persistence, lifecycle
+// decisions and crash recovery compiled by run.sh are the production sources.
+import Foundation
+
+enum ContextPolicy { enum CheckResult { case ok, needsCompact, exhausted } }
+enum ChatMessageRole { case user, assistant }
+enum AssistantBlockKind { case text }
+struct AssistantBlock { let kind: AssistantBlockKind; let content: String }
+final class ChatMessage {
+    let id = UUID()
+    let role: ChatMessageRole
+    let content: String
+    var blocks: [AssistantBlock] = []
+    var error: String?
+    var isQueued = false
+    init(role: ChatMessageRole, content: String) { self.role = role; self.content = content }
+}
+
+actor CompletionGate {
+    private var released = false
+    private var waiting: [CheckedContinuation<Void, Never>] = []
+    func wait() async {
+        if released { return }
+        await withCheckedContinuation { waiting.append($0) }
+    }
+    func release() {
+        released = true
+        let pending = waiting
+        waiting.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
+@MainActor
+final class AIChatViewModel {
+    static var sendCount = 0
+    static var activeSessionId: String?
+    var sessionId: String?
+    var sessionSource: String?
+    var isProcessing = false
+    var isCompacting = false
+    var promptQueue: [String] = []
+    var inputText = ""
+    var attachments: [String] = []
+    var editingMessageIndex: Int?
+    var showCompactBeforeSendPrompt = false
+    var showContextExhaustedPrompt = false
+    var messages: [ChatMessage] = []
+    var currentTask: Task<Void, Never>?
+    var userDidCancel = false
+    var canResume = false
+    private var gate = CompletionGate()
+
+    func loadSession(activateSession: Bool = true) async {
+        if activateSession { Self.activeSessionId = sessionId }
+    }
+    func ensureSessionReturningId(activateSession: Bool = true) async -> String {
+        if let sessionId { return sessionId }
+        let id = UUID().uuidString
+        sessionId = id
+        if activateSession { Self.activeSessionId = id }
+        await ChatStore.shared.create(id)
+        ViewModelCache.shared.entries[id] = self
+        return id
+    }
+    func checkContextBeforeSend() -> ContextPolicy.CheckResult { .ok }
+    func send() {
+        guard !isProcessing else { return }
+        Self.sendCount += 1
+        userDidCancel = false
+        messages.append(ChatMessage(role: .user, content: inputText))
+        inputText = ""
+        isProcessing = true
+        if let sessionId { SessionActivityTracker.shared.active.insert(sessionId) }
+        let completion = CompletionGate()
+        gate = completion
+        currentTask = Task { [weak self] in
+            await completion.wait()
+            guard let self else { return }
+            self.isProcessing = false
+            if let id = self.sessionId { SessionActivityTracker.shared.active.remove(id) }
+        }
+    }
+    func cancel() {
+        userDidCancel = true
+        isProcessing = false
+        currentTask?.cancel()
+        if let sessionId { SessionActivityTracker.shared.active.remove(sessionId) }
+        // Deliberately keep the gate closed: emulate a cancelled network call
+        // whose completion arrives late, after the UI already says stopped.
+    }
+    func complete(_ text: String = "finished") async {
+        messages.append(ChatMessage(role: .assistant, content: text))
+        let task = currentTask
+        await gate.release()
+        await task?.value
+    }
+}
+
+@MainActor
+final class ViewModelCache {
+    static let shared = ViewModelCache()
+    var entries: [String: AIChatViewModel] = [:]
+    func getOrCreate(for id: String) -> (vm: AIChatViewModel, isNew: Bool) {
+        if let vm = entries[id] { return (vm, false) }
+        let vm = AIChatViewModel()
+        vm.sessionId = id
+        entries[id] = vm
+        return (vm, true)
+    }
+    func createDraft() -> AIChatViewModel { AIChatViewModel() }
+}
+
+@MainActor
+final class SessionActivityTracker {
+    static let shared = SessionActivityTracker()
+    var active: Set<String> = []
+    func isActive(_ id: String) -> Bool { active.contains(id) }
+}
+
+@MainActor
+final class SessionLockStore {
+    static let shared = SessionLockStore()
+    var locked: Set<String> = []
+    func isVisuallyLocked(_ id: String) -> Bool { locked.contains(id) }
+}
+
+struct SessionModelBinding {
+    enum Source { case directEntry(modelEntryId: String) }
+    let sessionId: String
+    let primarySource: Source
+}
+@MainActor
+final class ProviderConfigStore {
+    static let shared = ProviderConfigStore()
+    func entry(for id: String) -> String? { id == "valid-model" ? id : nil }
+    func setBinding(_ binding: SessionModelBinding, for id: String) {}
+}
+
+actor ChatStore {
+    static let shared = ChatStore()
+    struct Session { var isRemote = false }
+    private var sessions: [String: Session] = [:]
+    func create(_ id: String) { sessions[id] = Session() }
+    func getSession(_ id: String) -> Session? { sessions[id] }
+    func updateSessionTitle(_ id: String, title: String, category: String? = nil) {}
+}

--- a/src/ios/Agent/Team/StandaloneTests/Tests/TeamHarnessTests/MinisTeamStoreTests.swift
+++ b/src/ios/Agent/Team/StandaloneTests/Tests/TeamHarnessTests/MinisTeamStoreTests.swift
@@ -1,0 +1,253 @@
+import XCTest
+@testable import TeamHarness
+
+@MainActor
+final class MinisTeamStoreTests: XCTestCase {
+    private func location() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory.appendingPathComponent("team.json")
+    }
+
+    private func makeBot(_ store: MinisTeamStore, _ name: String) throws -> MinisBotProfile {
+        try store.createBot(name: name, role: "Complete the assigned task")
+    }
+
+    private func settle() async {
+        for _ in 0..<30 { await Task.yield() }
+    }
+
+    private func stop(_ store: MinisTeamStore) async {
+        for task in store.tasks where !task.state.isTerminal { await store.cancel(taskID: task.id) }
+        for bot in store.bots {
+            if let id = bot.sessionID, let vm = ViewModelCache.shared.entries[id] {
+                await vm.complete("late result during test cleanup")
+            }
+        }
+        await settle()
+    }
+
+    func testThreeSlotLimitAndFixedSessionSerialization() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let a = try makeBot(store, "A"), b = try makeBot(store, "B")
+        let c = try makeBot(store, "C"), d = try makeBot(store, "D")
+        let a1 = try store.dispatch(botID: a.id, prompt: "first")
+        let a2 = try store.dispatch(botID: a.id, prompt: "second")
+        _ = try store.dispatch(botID: b.id, prompt: "third")
+        _ = try store.dispatch(botID: c.id, prompt: "fourth")
+        let d1 = try store.dispatch(botID: d.id, prompt: "fifth")
+        await store.refresh()
+        XCTAssertEqual(store.tasks.filter { $0.state == .running }.count, 3)
+        XCTAssertEqual(store.task(id: a2.id)?.state, .queued)
+        XCTAssertEqual(store.task(id: d1.id)?.state, .queued)
+        let session = try XCTUnwrap(store.bot(id: a.id)?.sessionID)
+        let vm = try XCTUnwrap(ViewModelCache.shared.entries[session])
+        await vm.complete("first answer")
+        await settle()
+        await store.refresh()
+        XCTAssertEqual(store.task(id: a1.id)?.state, .completed)
+        XCTAssertEqual(store.task(id: a1.id)?.result, "first answer")
+        XCTAssertEqual(store.task(id: a2.id)?.state, .running)
+        XCTAssertEqual(store.task(id: a2.id)?.sessionID, session)
+        XCTAssertEqual(store.tasks.filter { $0.state == .running }.count, 3)
+        XCTAssertEqual(Set(store.tasks.filter { $0.state == .running }.map(\.botID)).count, 3)
+        await stop(store)
+    }
+
+    func testCancelledNativeTaskOccupiesSlotUntilCleanupAndLateResultCannotOverwrite() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let bot = try makeBot(store, "Worker")
+        let first = try store.dispatch(botID: bot.id, prompt: "one")
+        let second = try store.dispatch(botID: bot.id, prompt: "two")
+        await store.refresh()
+        let sid = try XCTUnwrap(store.bot(id: bot.id)?.sessionID)
+        let vm = try XCTUnwrap(ViewModelCache.shared.entries[sid])
+        await store.cancel(taskID: first.id)
+        await store.refresh()
+        XCTAssertEqual(store.task(id: first.id)?.state, .cancelled)
+        XCTAssertEqual(store.task(id: second.id)?.state, .queued)
+        XCTAssertFalse(vm.isProcessing, "The native UI can say stopped while cleanup is still pending")
+        await vm.complete("response that arrived after cancellation")
+        await settle()
+        await store.refresh()
+        XCTAssertEqual(store.task(id: first.id)?.state, .cancelled)
+        XCTAssertNil(store.task(id: first.id)?.result)
+        XCTAssertEqual(store.task(id: second.id)?.state, .running)
+        await stop(store)
+    }
+
+    func testRestartInterruptsBothQueuedAndRunningWithoutSendingAgain() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let firstStore = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let bot = try makeBot(firstStore, "Worker")
+        _ = try firstStore.dispatch(botID: bot.id, prompt: "running task")
+        _ = try firstStore.dispatch(botID: bot.id, prompt: "queued task")
+        await firstStore.refresh()
+        let sends = AIChatViewModel.sendCount
+        let restored = MinisTeamStore(fileURL: url, automaticPolling: false)
+        XCTAssertEqual(restored.tasks.count, 2)
+        XCTAssertTrue(restored.tasks.allSatisfy { $0.state == .interrupted })
+        await restored.refresh()
+        XCTAssertEqual(AIChatViewModel.sendCount, sends)
+        XCTAssertEqual(restored.bots.first?.sessionID, firstStore.bots.first?.sessionID)
+        await stop(firstStore)
+    }
+
+    func testPersistentRequestIDRejectsConflictAndSurvivesDeletedProfile() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let bot = try makeBot(store, "Worker")
+        let first = try store.dispatch(botID: bot.id, prompt: "task", sourceSessionID: "parent", requestID: "call_1")
+        let replay = try store.dispatch(botID: bot.id, prompt: "task", sourceSessionID: "parent", requestID: "call_1")
+        XCTAssertEqual(first.id, replay.id)
+        XCTAssertEqual(store.tasks.count, 1)
+        XCTAssertThrowsError(try store.dispatch(botID: bot.id, prompt: "changed", sourceSessionID: "parent", requestID: "call_1"))
+        await store.cancel(taskID: first.id)
+        try store.deleteBot(id: bot.id)
+        let restored = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let replayAfterDelete = try restored.dispatch(botID: bot.id, prompt: "task", sourceSessionID: "parent", requestID: "call_1")
+        XCTAssertEqual(replayAfterDelete.id, first.id)
+        XCTAssertEqual(replayAfterDelete.state, .cancelled)
+        XCTAssertTrue(restored.bots.isEmpty)
+    }
+
+    func testStorageFailureBeforeDispatchDoesNotStartModel() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let bot = try makeBot(store, "Worker")
+        let task = try store.dispatch(botID: bot.id, prompt: "must not send")
+        let sends = AIChatViewModel.sendCount
+        let directory = url.deletingLastPathComponent()
+        try FileManager.default.removeItem(at: directory)
+        try Data("not a directory".utf8).write(to: directory)
+        await store.refresh()
+        XCTAssertEqual(AIChatViewModel.sendCount, sends)
+        XCTAssertNotNil(store.storageError)
+        XCTAssertEqual(store.task(id: task.id)?.state, .queued)
+    }
+
+    func testUnreadableDocumentIsNotReplaced() throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let original = Data("this is not a team document".utf8)
+        try original.write(to: url)
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        XCTAssertNotNil(store.storageError)
+        XCTAssertThrowsError(try makeBot(store, "Worker"))
+        XCTAssertEqual(try Data(contentsOf: url), original)
+    }
+
+    func testQueuedCancellationSurvivesWriteFailureAndUnrelatedSuccessfulMutation() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let bot = try makeBot(store, "Worker")
+        let task = try store.dispatch(botID: bot.id, prompt: "cancel before running")
+        let sends = AIChatViewModel.sendCount
+        let directory = url.deletingLastPathComponent()
+        try FileManager.default.removeItem(at: directory)
+        try Data("disk failure".utf8).write(to: directory)
+        await store.cancel(taskID: task.id)
+        XCTAssertNotNil(store.storageError)
+        try FileManager.default.removeItem(at: directory)
+        _ = try makeBot(store, "Unrelated mutation")
+        XCTAssertNil(store.storageError)
+        await store.refresh()
+        XCTAssertEqual(store.task(id: task.id)?.state, .cancelled)
+        XCTAssertEqual(AIChatViewModel.sendCount, sends)
+    }
+
+    func testTaskContentLocksFollowBothSessionsDynamically() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let bot = try makeBot(store, "Worker")
+        let queued = try store.dispatch(botID: bot.id, prompt: "private", sourceSessionID: "parent-locked-test")
+        XCTAssertFalse(store.isTaskContentLocked(queued))
+        SessionLockStore.shared.locked.insert("parent-locked-test")
+        XCTAssertTrue(store.isTaskContentLocked(queued))
+        SessionLockStore.shared.locked.remove("parent-locked-test")
+        await store.refresh()
+        let running = try XCTUnwrap(store.task(id: queued.id))
+        let sid = try XCTUnwrap(running.sessionID)
+        SessionLockStore.shared.locked.insert(sid)
+        XCTAssertTrue(store.isTaskContentLocked(running))
+        SessionLockStore.shared.locked.remove(sid)
+        XCTAssertFalse(store.isTaskContentLocked(running))
+        await stop(store)
+    }
+
+    func testBotOriginCannotDispatchAndBusyProfileCannotChange() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let bot = try makeBot(store, "Worker")
+        _ = try store.dispatch(botID: bot.id, prompt: "work")
+        XCTAssertThrowsError(try store.updateBot(id: bot.id, name: "new", role: "new role", modelEntryID: nil))
+        await store.refresh()
+        let sid = try XCTUnwrap(store.bot(id: bot.id)?.sessionID)
+        XCTAssertThrowsError(try store.dispatch(botID: bot.id, prompt: "recurse", sourceSessionID: sid))
+        await stop(store)
+    }
+
+    func testTeamSessionCreationDoesNotChangeForegroundConversation() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let bot = try makeBot(store, "Worker")
+        AIChatViewModel.activeSessionId = "user-foreground"
+        _ = try store.dispatch(botID: bot.id, prompt: "work")
+        await store.refresh()
+        XCTAssertEqual(AIChatViewModel.activeSessionId, "user-foreground")
+        await stop(store)
+    }
+
+    func testTeamCancelDoesNotStopStartedManualFollowUp() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let bot = try makeBot(store, "Worker")
+        let task = try store.dispatch(botID: bot.id, prompt: "original")
+        await store.refresh()
+        let sid = try XCTUnwrap(store.bot(id: bot.id)?.sessionID)
+        let vm = try XCTUnwrap(ViewModelCache.shared.entries[sid])
+        vm.messages.append(ChatMessage(role: .assistant, content: "original result"))
+        vm.messages.append(ChatMessage(role: .user, content: "manual follow-up now running"))
+        await store.cancel(taskID: task.id)
+        XCTAssertEqual(store.task(id: task.id)?.state, .cancelled)
+        XCTAssertTrue(vm.isProcessing)
+        XCTAssertFalse(vm.currentTask?.isCancelled ?? true)
+        await vm.complete("manual answer")
+        await settle()
+        XCTAssertNil(store.task(id: task.id)?.result)
+    }
+
+    func testBusyConversationDoesNotBlockOtherBotsOrOverwriteDraft() async throws {
+        let url = try location()
+        defer { try? FileManager.default.removeItem(at: url.deletingLastPathComponent()) }
+        let store = MinisTeamStore(fileURL: url, automaticPolling: false)
+        let first = try makeBot(store, "A")
+        _ = try store.dispatch(botID: first.id, prompt: "initial")
+        await store.refresh()
+        let sid = try XCTUnwrap(store.bot(id: first.id)?.sessionID)
+        let vm = try XCTUnwrap(ViewModelCache.shared.entries[sid])
+        await vm.complete()
+        await settle()
+        vm.inputText = "User's unsent draft"
+        let blocked = try store.dispatch(botID: first.id, prompt: "must wait")
+        let other = try makeBot(store, "B")
+        let ready = try store.dispatch(botID: other.id, prompt: "can run")
+        await store.refresh()
+        XCTAssertEqual(store.task(id: blocked.id)?.state, .queued)
+        XCTAssertEqual(store.task(id: ready.id)?.state, .running)
+        XCTAssertEqual(vm.inputText, "User's unsent draft")
+        await stop(store)
+    }
+}

--- a/src/ios/Agent/Team/StandaloneTests/run.sh
+++ b/src/ios/Agent/Team/StandaloneTests/run.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+fixture_dir="$(cd "$(dirname "$0")" && pwd)"
+team_source_dir="$(cd "$fixture_dir/.." && pwd)"
+team_test_dir="$(mktemp -d "${TMPDIR:-/tmp}/minis-team-tests.XXXXXX")"
+trap 'rm -rf "$team_test_dir"' EXIT
+cp -R "$fixture_dir/Package.swift" "$fixture_dir/Sources" "$fixture_dir/Tests" "$team_test_dir/"
+cp "$team_source_dir/MinisTeamStore.swift" "$team_source_dir/MinisTeamModels.swift" "$team_test_dir/Sources/TeamHarness/"
+swift test --package-path "$team_test_dir"

--- a/src/ios/FileProvider/AppGroupChangeWatcher.swift
+++ b/src/ios/FileProvider/AppGroupChangeWatcher.swift
@@ -45,6 +45,10 @@ final class AppGroupChangeWatcher {
     /// Start watching the three exposed roots. Idempotent — calling twice is a no-op.
     func start() {
         guard !started else { return }
+        guard SharedContainerStore.isAppGroupAvailable else {
+            logger.warning("App Group unavailable; Files change watcher is disabled for private storage.")
+            return
+        }
         started = true
 
         let fm = FileManager.default

--- a/src/ios/FileProvider/FileProviderEnumerator.swift
+++ b/src/ios/FileProvider/FileProviderEnumerator.swift
@@ -18,7 +18,11 @@ final class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
     // MARK: - Full enumeration (initial sync)
 
     func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
-        let items = listItems()
+        guard let root = FileProviderExtension.providerRoot else {
+            observer.finishEnumeratingWithError(FileProviderExtension.appGroupUnavailableError)
+            return
+        }
+        let items = listItems(providerRoot: root)
         os_log("enumerateItems container=%{public}@ recursive=%d count=%d",
                log: Self.log, type: .info,
                containerItemIdentifier.rawValue, recursive ? 1 : 0, items.count)
@@ -30,8 +34,12 @@ final class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
     // MARK: - Change enumeration (incremental updates)
 
     func enumerateChanges(for observer: NSFileProviderChangeObserver, from syncAnchor: NSFileProviderSyncAnchor) {
-        let currentAnchor = buildSyncAnchor()
-        let items = listItems()
+        guard let root = FileProviderExtension.providerRoot else {
+            observer.finishEnumeratingWithError(FileProviderExtension.appGroupUnavailableError)
+            return
+        }
+        let currentAnchor = buildSyncAnchor(providerRoot: root)
+        let items = listItems(providerRoot: root)
         os_log("enumerateChanges container=%{public}@ anchorMatch=%d itemCount=%d",
                log: Self.log, type: .info,
                containerItemIdentifier.rawValue,
@@ -62,7 +70,15 @@ final class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
     }
 
     func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
-        completionHandler(buildSyncAnchor())
+        guard let root = FileProviderExtension.providerRoot else {
+            // This protocol callback has no Error parameter; nil means no
+            // usable anchor. Enumeration requests report the explicit error.
+            os_log("currentSyncAnchor unavailable: App Group container is not authorized",
+                   log: Self.log, type: .error)
+            completionHandler(nil)
+            return
+        }
+        completionHandler(buildSyncAnchor(providerRoot: root))
     }
 
     /// Hex-encode an 8-byte anchor for human-readable log lines. Falls back
@@ -102,28 +118,28 @@ final class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
         return false
     }
 
-    private func directoryURL() -> URL {
+    private func directoryURL(providerRoot: URL) -> URL {
         if containerItemIdentifier == .rootContainer {
-            return FileProviderExtension.providerRoot
+            return providerRoot
         }
-        return FileProviderExtension.providerRoot
+        return providerRoot
             .appendingPathComponent(containerItemIdentifier.rawValue)
     }
 
-    private func listItems() -> [FileProviderItem] {
+    private func listItems(providerRoot: URL) -> [FileProviderItem] {
         // Trash is not supported — always return empty.
         if containerItemIdentifier == .trashContainer {
             return []
         }
 
-        let dirURL = directoryURL()
+        let dirURL = directoryURL(providerRoot: providerRoot)
         let fm = FileManager.default
         if containerItemIdentifier == .rootContainer {
             try? fm.createDirectory(at: dirURL, withIntermediateDirectories: true)
         }
 
         if recursive {
-            return listItemsRecursively(at: dirURL, parentIdentifier: containerItemIdentifier)
+            return listItemsRecursively(at: dirURL, providerRoot: providerRoot, parentIdentifier: containerItemIdentifier)
         }
 
         guard var contents = try? fm.contentsOfDirectory(
@@ -158,12 +174,12 @@ final class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
         }
 
         return contents.map { url in
-            FileProviderItem(url: url, parentIdentifier: containerItemIdentifier)
+            FileProviderItem(url: url, providerRoot: providerRoot, parentIdentifier: containerItemIdentifier)
         }
     }
 
     /// Recursively list all items under a directory for the working set.
-    private func listItemsRecursively(at dirURL: URL, parentIdentifier: NSFileProviderItemIdentifier) -> [FileProviderItem] {
+    private func listItemsRecursively(at dirURL: URL, providerRoot: URL, parentIdentifier: NSFileProviderItemIdentifier) -> [FileProviderItem] {
         let fm = FileManager.default
         guard var contents = try? fm.contentsOfDirectory(
             at: dirURL,
@@ -176,7 +192,7 @@ final class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
         // Defensive: same reserved-identifier filter as the non-recursive path.
         contents = contents.filter { !Self.isHiddenMetadata($0.lastPathComponent) }
 
-        let rootURL = FileProviderExtension.providerRoot
+        let rootURL = providerRoot
         // At the provider root, apply the same hidden-folder filter as the
         // non-recursive path so hidden top-level subdirs don't leak into the
         // working set when iOS Files enumerates recursively.
@@ -194,7 +210,7 @@ final class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
         let root = rootURL.path
         var items: [FileProviderItem] = []
         for url in contents {
-            let item = FileProviderItem(url: url, parentIdentifier: parentIdentifier)
+            let item = FileProviderItem(url: url, providerRoot: providerRoot, parentIdentifier: parentIdentifier)
             items.append(item)
 
             var isDir: ObjCBool = false
@@ -204,7 +220,7 @@ final class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
                 let childParentID = relative.isEmpty
                     ? NSFileProviderItemIdentifier.rootContainer
                     : NSFileProviderItemIdentifier(relative)
-                items.append(contentsOf: listItemsRecursively(at: url, parentIdentifier: childParentID))
+                items.append(contentsOf: listItemsRecursively(at: url, providerRoot: providerRoot, parentIdentifier: childParentID))
             }
         }
         return items
@@ -213,8 +229,8 @@ final class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
     /// Build a compact, deterministic sync anchor from directory contents.
     /// Uses a fixed-size 8-byte representation to avoid exceeding the system's
     /// vendor-token size limit (which causes an assertion in FPXObserver).
-    private func buildSyncAnchor() -> NSFileProviderSyncAnchor {
-        let items = listItems()
+    private func buildSyncAnchor(providerRoot: URL) -> NSFileProviderSyncAnchor {
+        let items = listItems(providerRoot: providerRoot)
 
         // Base hash: item count (even 0 is fine — we still fold visibility in below).
         var hash: UInt64 = UInt64(items.count)

--- a/src/ios/FileProvider/FileProviderExtension.swift
+++ b/src/ios/FileProvider/FileProviderExtension.swift
@@ -12,13 +12,24 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
     private static let log = OSLog(subsystem: "com.openminis.app.FileProvider", category: "Extension")
 
     /// Root directory for all FileProvider-visible files in the App Group container.
-    static var providerRoot: URL {
-        let container = FileManager.default.containerURL(
+    /// A re-signed installation may have no App Group entitlement. The extension
+    /// must stay unavailable in that case, never substitute its private container.
+    static var providerRoot: URL? {
+        guard let container = FileManager.default.containerURL(
             forSecurityApplicationGroupIdentifier: "group.com.openminis.app"
-        )!
+        ) else { return nil }
         let url = container.appendingPathComponent("MinisFileProvider", isDirectory: true)
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
+    }
+
+    static var appGroupUnavailableError: NSError {
+        NSError(
+            domain: NSCocoaErrorDomain,
+            code: NSFileReadNoPermissionError,
+            userInfo: [NSLocalizedDescriptionKey:
+                "当前签名无法访问 Minis 的共享容器，系统“文件”集成不可用。请在 Minis 内查看文件。"]
+        )
     }
 
     /// The three top-level subdirectories exposed via the FileProvider.
@@ -28,7 +39,11 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         self.domain = domain
         super.init()
         let fm = FileManager.default
-        let root = Self.providerRoot
+        guard let root = Self.providerRoot else {
+            os_log("FileProvider unavailable: App Group container is not authorized",
+                   log: Self.log, type: .error)
+            return
+        }
         for sub in Self.topLevelSubdirs {
             try? fm.createDirectory(at: root.appendingPathComponent(sub, isDirectory: true),
                                     withIntermediateDirectories: true)
@@ -179,16 +194,20 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     func item(for identifier: NSFileProviderItemIdentifier, request: NSFileProviderRequest,
               completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) -> Progress {
+        guard let root = Self.providerRoot else {
+            completionHandler(nil, Self.appGroupUnavailableError)
+            return Progress()
+        }
         os_log("item(for: %{public}@)", log: Self.log, type: .debug, identifier.rawValue)
         if identifier == .rootContainer {
-            completionHandler(FileProviderItem(url: Self.providerRoot, parentIdentifier: .rootContainer, isRoot: true), nil)
+            completionHandler(FileProviderItem(url: root, providerRoot: root, parentIdentifier: .rootContainer, isRoot: true), nil)
             return Progress()
         }
         if identifier == .trashContainer {
             completionHandler(nil, NSFileProviderError(.noSuchItem))
             return Progress()
         }
-        let url = Self.providerRoot.appendingPathComponent(identifier.rawValue)
+        let url = root.appendingPathComponent(identifier.rawValue)
         guard FileManager.default.fileExists(atPath: url.path) else {
             completionHandler(nil, NSFileProviderError(.noSuchItem))
             return Progress()
@@ -197,7 +216,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         let parentID = parentPath.isEmpty
             ? NSFileProviderItemIdentifier.rootContainer
             : NSFileProviderItemIdentifier(parentPath)
-        completionHandler(FileProviderItem(url: url, parentIdentifier: parentID), nil)
+        completionHandler(FileProviderItem(url: url, providerRoot: root, parentIdentifier: parentID), nil)
         return Progress()
     }
 
@@ -205,6 +224,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
 
     func enumerator(for containerItemIdentifier: NSFileProviderItemIdentifier,
                     request: NSFileProviderRequest) throws -> NSFileProviderEnumerator {
+        guard Self.providerRoot != nil else { throw Self.appGroupUnavailableError }
         os_log("enumerator(for: %{public}@)", log: Self.log, type: .info, containerItemIdentifier.rawValue)
 
         switch containerItemIdentifier {
@@ -225,7 +245,11 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                        version requestedVersion: NSFileProviderItemVersion?,
                        request: NSFileProviderRequest,
                        completionHandler: @escaping (URL?, NSFileProviderItem?, Error?) -> Void) -> Progress {
-        let url = Self.providerRoot.appendingPathComponent(itemIdentifier.rawValue)
+        guard let root = Self.providerRoot else {
+            completionHandler(nil, nil, Self.appGroupUnavailableError)
+            return Progress()
+        }
+        let url = root.appendingPathComponent(itemIdentifier.rawValue)
         guard FileManager.default.fileExists(atPath: url.path) else {
             completionHandler(nil, nil, NSFileProviderError(.noSuchItem))
             return Progress()
@@ -234,7 +258,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
         let parentID = parentPath.isEmpty
             ? NSFileProviderItemIdentifier.rootContainer
             : NSFileProviderItemIdentifier(parentPath)
-        let item = FileProviderItem(url: url, parentIdentifier: parentID)
+        let item = FileProviderItem(url: url, providerRoot: root, parentIdentifier: parentID)
 
         let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         do {
@@ -256,6 +280,10 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                     options: NSFileProviderCreateItemOptions = [],
                     request: NSFileProviderRequest,
                     completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
+        guard let root = Self.providerRoot else {
+            completionHandler(nil, [], false, Self.appGroupUnavailableError)
+            return Progress()
+        }
         // Block creation directly under root — only the fixed subdirs live there.
         // Block creation under memory/ or skills/ (read-only trees).
         // Block creation under trashContainer — we do not support a trash and
@@ -272,7 +300,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
-        let parentURL = Self.providerRoot.appendingPathComponent(itemTemplate.parentItemIdentifier.rawValue)
+        let parentURL = root.appendingPathComponent(itemTemplate.parentItemIdentifier.rawValue)
         let destURL = parentURL.appendingPathComponent(itemTemplate.filename)
 
         do {
@@ -284,7 +312,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                 }
                 try FileManager.default.copyItem(at: sourceURL, to: destURL)
             }
-            let item = FileProviderItem(url: destURL, parentIdentifier: itemTemplate.parentItemIdentifier)
+            let item = FileProviderItem(url: destURL, providerRoot: root, parentIdentifier: itemTemplate.parentItemIdentifier)
             completionHandler(item, [], false, nil)
             signalParent(itemTemplate.parentItemIdentifier)
         } catch {
@@ -302,6 +330,10 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                     options: NSFileProviderModifyItemOptions = [],
                     request: NSFileProviderRequest,
                     completionHandler: @escaping (NSFileProviderItem?, NSFileProviderItemFields, Bool, Error?) -> Void) -> Progress {
+        guard let root = Self.providerRoot else {
+            completionHandler(nil, [], false, Self.appGroupUnavailableError)
+            return Progress()
+        }
         let idRaw = item.itemIdentifier.rawValue
 
         // Block rename/move of the three fixed top-level subdirectories.
@@ -333,16 +365,16 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
-        let srcURL = Self.providerRoot.appendingPathComponent(item.itemIdentifier.rawValue)
+        let srcURL = root.appendingPathComponent(item.itemIdentifier.rawValue)
 
         do {
             var destURL = srcURL
             if changedFields.contains(.filename) || changedFields.contains(.parentItemIdentifier) {
                 let parentURL: URL
                 if item.parentItemIdentifier == .rootContainer {
-                    parentURL = Self.providerRoot
+                    parentURL = root
                 } else {
-                    parentURL = Self.providerRoot.appendingPathComponent(item.parentItemIdentifier.rawValue)
+                    parentURL = root.appendingPathComponent(item.parentItemIdentifier.rawValue)
                 }
                 destURL = parentURL.appendingPathComponent(item.filename)
                 if srcURL != destURL {
@@ -357,7 +389,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                 try FileManager.default.copyItem(at: newContents, to: destURL)
             }
 
-            let resultItem = FileProviderItem(url: destURL, parentIdentifier: item.parentItemIdentifier)
+            let resultItem = FileProviderItem(url: destURL, providerRoot: root, parentIdentifier: item.parentItemIdentifier)
             completionHandler(resultItem, [], false, nil)
             signalParent(item.parentItemIdentifier)
         } catch {
@@ -373,6 +405,10 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
                     options: NSFileProviderDeleteItemOptions = [],
                     request: NSFileProviderRequest,
                     completionHandler: @escaping (Error?) -> Void) -> Progress {
+        guard let root = Self.providerRoot else {
+            completionHandler(Self.appGroupUnavailableError)
+            return Progress()
+        }
         os_log("deleteItem id=%{public}@", log: Self.log, type: .info, identifier.rawValue)
 
         let idRaw = identifier.rawValue
@@ -383,7 +419,7 @@ final class FileProviderExtension: NSObject, NSFileProviderReplicatedExtension {
             return Progress()
         }
 
-        let url = Self.providerRoot.appendingPathComponent(identifier.rawValue)
+        let url = root.appendingPathComponent(identifier.rawValue)
         if FileManager.default.fileExists(atPath: url.path) {
             do {
                 try FileManager.default.removeItem(at: url)

--- a/src/ios/FileProvider/FileProviderItem.swift
+++ b/src/ios/FileProvider/FileProviderItem.swift
@@ -4,12 +4,14 @@ import UniformTypeIdentifiers
 /// Maps a file or directory in the shared folder to FileProvider item metadata.
 final class FileProviderItem: NSObject, NSFileProviderItem {
     private let fileURL: URL
+    private let providerRoot: URL
     private let parentID: NSFileProviderItemIdentifier
     private let attrs: [FileAttributeKey: Any]?
     private let isRoot: Bool
 
-    init(url: URL, parentIdentifier: NSFileProviderItemIdentifier, isRoot: Bool = false) {
+    init(url: URL, providerRoot: URL, parentIdentifier: NSFileProviderItemIdentifier, isRoot: Bool = false) {
         self.fileURL = url
+        self.providerRoot = providerRoot
         self.parentID = parentIdentifier
         self.attrs = try? FileManager.default.attributesOfItem(atPath: url.path)
         self.isRoot = isRoot
@@ -18,7 +20,7 @@ final class FileProviderItem: NSObject, NSFileProviderItem {
 
     var itemIdentifier: NSFileProviderItemIdentifier {
         if isRoot { return .rootContainer }
-        let root = FileProviderExtension.providerRoot
+        let root = providerRoot
         let relative = fileURL.path.replacingOccurrences(of: root.path, with: "")
             .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         if relative.isEmpty {

--- a/src/ios/Minis.xcodeproj/project.pbxproj
+++ b/src/ios/Minis.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3BD594A899B4A4A203556F7E /* CodexOAuthToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFDF3F2056928A4962F3F5D /* CodexOAuthToken.swift */; };
+		AFA914F7B2F9512705D3B2EF /* CodexModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E4EAE2D0FA503273FC484 /* CodexModelCatalog.swift */; };
+		382AE5C205C86C0759C093FC /* CodexModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E4EAE2D0FA503273FC484 /* CodexModelCatalog.swift */; };
+		7AA388FECCB20AAA257CD5DB /* CodexOAuthToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFDF3F2056928A4962F3F5D /* CodexOAuthToken.swift */; };
 		21FED4B7BB6F6D9476C9992E /* VoiceProvider+System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88993FC8E3F0199C6638F664 /* VoiceProvider+System.swift */; };
 		241D530017827D7F0EB604DE /* VoiceProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2941B643B8A2F048A2B154E /* VoiceProviderFactory.swift */; };
 		2A4FD49F872431D703328384 /* VoiceOutputPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424510790AF3FB2452D3CCE3 /* VoiceOutputPlayer.swift */; };
@@ -605,6 +609,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		302E4EAE2D0FA503273FC484 /* CodexModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "CodexModelCatalog.swift"; path = "Providers/OpenAI/OAuth/CodexModelCatalog.swift"; sourceTree = SOURCE_ROOT; };
+		DDFDF3F2056928A4962F3F5D /* CodexOAuthToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "CodexOAuthToken.swift"; path = "Providers/OpenAI/OAuth/CodexOAuthToken.swift"; sourceTree = SOURCE_ROOT; };
 		0ED149397BEA7E0408C92688 /* GroupVoiceModelsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupVoiceModelsView.swift; sourceTree = "<group>"; };
 		0F5379380323FA8C6477708C /* GroupSlotPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupSlotPicker.swift; sourceTree = "<group>"; };
 		16FF3462D09402F14B610CD6 /* VoiceWaveformView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceWaveformView.swift; sourceTree = "<group>"; };
@@ -1421,6 +1427,8 @@
 		E51000030 = {
 			isa = PBXGroup;
 			children = (
+				302E4EAE2D0FA503273FC484 /* CodexModelCatalog.swift */,
+				DDFDF3F2056928A4962F3F5D /* CodexOAuthToken.swift */,
 				E51000031 /* Minis */,
 				E5E000031 /* Shared */,
 				E5E000030 /* ShareExtension */,
@@ -2632,6 +2640,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3BD594A899B4A4A203556F7E /* CodexOAuthToken.swift in Sources */,
+				AFA914F7B2F9512705D3B2EF /* CodexModelCatalog.swift in Sources */,
 				BB1000120F700000000000AA /* ContextPolicy.swift in Sources */,
 				E5LD00002 /* ToolLoopDetector.swift in Sources */,
 				E5GWF0004 /* GeminiWireFormat.swift in Sources */,
@@ -2661,6 +2671,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				382AE5C205C86C0759C093FC /* CodexModelCatalog.swift in Sources */,
+				7AA388FECCB20AAA257CD5DB /* CodexOAuthToken.swift in Sources */,
 				AC0000202 /* ProviderCustomizationGenerated.swift in Sources */,
 				E54000AC1 /* DebugSkillGenerated.swift in Sources */,
 				E5FP00100 /* AppGroupChangeWatcher.swift in Sources */,

--- a/src/ios/Minis.xcodeproj/project.pbxproj
+++ b/src/ios/Minis.xcodeproj/project.pbxproj
@@ -10,7 +10,11 @@
 		3BD594A899B4A4A203556F7E /* CodexOAuthToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFDF3F2056928A4962F3F5D /* CodexOAuthToken.swift */; };
 		AFA914F7B2F9512705D3B2EF /* CodexModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E4EAE2D0FA503273FC484 /* CodexModelCatalog.swift */; };
 		382AE5C205C86C0759C093FC /* CodexModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 302E4EAE2D0FA503273FC484 /* CodexModelCatalog.swift */; };
+		B0F3206EA3A50DCEAA3FA036 /* MinisTeamView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28A3AC51683332D025EF12A3 /* MinisTeamView.swift */; };
 		7AA388FECCB20AAA257CD5DB /* CodexOAuthToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDFDF3F2056928A4962F3F5D /* CodexOAuthToken.swift */; };
+		E4050AC790CA7EB570E34D3C /* MinisTeamStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFFB318A8E2B6E25B724B3E /* MinisTeamStore.swift */; };
+		9039F5AB6A94151C500BD268 /* MinisTeamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DA4AF3E8B3AFB871650E01D /* MinisTeamModels.swift */; };
+		C0B869CF49292F889C7AC7C1 /* AIChatViewModel+TeamTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39B411F381ABE5E523B32A12 /* AIChatViewModel+TeamTools.swift */; };
 		21FED4B7BB6F6D9476C9992E /* VoiceProvider+System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88993FC8E3F0199C6638F664 /* VoiceProvider+System.swift */; };
 		241D530017827D7F0EB604DE /* VoiceProviderFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2941B643B8A2F048A2B154E /* VoiceProviderFactory.swift */; };
 		2A4FD49F872431D703328384 /* VoiceOutputPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 424510790AF3FB2452D3CCE3 /* VoiceOutputPlayer.swift */; };
@@ -610,7 +614,11 @@
 
 /* Begin PBXFileReference section */
 		302E4EAE2D0FA503273FC484 /* CodexModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "CodexModelCatalog.swift"; path = "Providers/OpenAI/OAuth/CodexModelCatalog.swift"; sourceTree = SOURCE_ROOT; };
+		28A3AC51683332D025EF12A3 /* MinisTeamView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "MinisTeamView.swift"; path = "Views/Team/MinisTeamView.swift"; sourceTree = SOURCE_ROOT; };
 		DDFDF3F2056928A4962F3F5D /* CodexOAuthToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "CodexOAuthToken.swift"; path = "Providers/OpenAI/OAuth/CodexOAuthToken.swift"; sourceTree = SOURCE_ROOT; };
+		9FFFB318A8E2B6E25B724B3E /* MinisTeamStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "MinisTeamStore.swift"; path = "Agent/Team/MinisTeamStore.swift"; sourceTree = SOURCE_ROOT; };
+		0DA4AF3E8B3AFB871650E01D /* MinisTeamModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "MinisTeamModels.swift"; path = "Agent/Team/MinisTeamModels.swift"; sourceTree = SOURCE_ROOT; };
+		39B411F381ABE5E523B32A12 /* AIChatViewModel+TeamTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "AIChatViewModel+TeamTools.swift"; path = "Agent/Chat/AIChatViewModel+TeamTools.swift"; sourceTree = SOURCE_ROOT; };
 		0ED149397BEA7E0408C92688 /* GroupVoiceModelsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupVoiceModelsView.swift; sourceTree = "<group>"; };
 		0F5379380323FA8C6477708C /* GroupSlotPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GroupSlotPicker.swift; sourceTree = "<group>"; };
 		16FF3462D09402F14B610CD6 /* VoiceWaveformView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceWaveformView.swift; sourceTree = "<group>"; };
@@ -1428,7 +1436,11 @@
 			isa = PBXGroup;
 			children = (
 				302E4EAE2D0FA503273FC484 /* CodexModelCatalog.swift */,
+				28A3AC51683332D025EF12A3 /* MinisTeamView.swift */,
 				DDFDF3F2056928A4962F3F5D /* CodexOAuthToken.swift */,
+				9FFFB318A8E2B6E25B724B3E /* MinisTeamStore.swift */,
+				0DA4AF3E8B3AFB871650E01D /* MinisTeamModels.swift */,
+				39B411F381ABE5E523B32A12 /* AIChatViewModel+TeamTools.swift */,
 				E51000031 /* Minis */,
 				E5E000031 /* Shared */,
 				E5E000030 /* ShareExtension */,
@@ -2672,7 +2684,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				382AE5C205C86C0759C093FC /* CodexModelCatalog.swift in Sources */,
+				B0F3206EA3A50DCEAA3FA036 /* MinisTeamView.swift in Sources */,
 				7AA388FECCB20AAA257CD5DB /* CodexOAuthToken.swift in Sources */,
+				E4050AC790CA7EB570E34D3C /* MinisTeamStore.swift in Sources */,
+				9039F5AB6A94151C500BD268 /* MinisTeamModels.swift in Sources */,
+				C0B869CF49292F889C7AC7C1 /* AIChatViewModel+TeamTools.swift in Sources */,
 				AC0000202 /* ProviderCustomizationGenerated.swift in Sources */,
 				E54000AC1 /* DebugSkillGenerated.swift in Sources */,
 				E5FP00100 /* AppGroupChangeWatcher.swift in Sources */,

--- a/src/ios/MinisApp.swift
+++ b/src/ios/MinisApp.swift
@@ -740,6 +740,11 @@ struct MinisApp: App {
         // keeps the cache fresh after ensureExists() seeds a first-launch SOUL.md.
         SoulStore.refreshCache()
 
+        guard SharedContainerStore.isAppGroupAvailable else {
+            lifecycleLog.warning("[FileProvider] App Group unavailable; using private Library storage. Files integration and extension sharing are unavailable; domain registration skipped.")
+            return
+        }
+
         // Clean up stale directory created by a bug where workingSet identifier
         // was passed through as a subdirectory name.
         let staleDir = root.appendingPathComponent("shared/NSFileProviderWorkingSetContainerItemIdentifier")
@@ -888,6 +893,7 @@ struct MinisApp: App {
     }
 
     private static func signalFileProvider() {
+        guard SharedContainerStore.isAppGroupAvailable else { return }
         NSFileProviderManager(for: fileProviderDomain)?.signalEnumerator(for: .rootContainer) { error in
             if let error {
                 lifecycleLog.warning("[FileProvider] signal failed: \(error.localizedDescription)")
@@ -1044,8 +1050,12 @@ struct MinisApp: App {
     /// 4. Old App Group MinisShared/ → App Group MinisFileProvider/shared/
     private static func migrateSharedDirToAppGroup() {
         let fm = FileManager.default
+        guard let container = SharedContainerStore.containerURL else {
+            // Leave all historical shared/local data in place. Re-signing
+            // does not authorize access to the former shared container.
+            return
+        }
         let library = fm.urls(for: .libraryDirectory, in: .userDomainMask).first!
-        let container = fm.containerURL(forSecurityApplicationGroupIdentifier: "group.com.openminis.app")!
 
         let migrations: [(source: URL, dest: URL, label: String)] = [
             // Legacy Library/MinisChat/shared → new shared

--- a/src/ios/MinisTests/CodexOAuthTests.swift
+++ b/src/ios/MinisTests/CodexOAuthTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import XCTest
+
+final class CodexOAuthTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private func jwt(_ claims: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: claims)
+        let payload = data.base64EncodedString().replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "=", with: "")
+        return "e30.\(payload).test-signature"
+    }
+
+    private func response(_ fields: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: fields)
+    }
+
+    func testNamespaceClaimsAndAccessExpiryWithoutExpiresIn() throws {
+        let access = try jwt(["exp": now.timeIntervalSince1970 + 3600])
+        let id = try jwt(["https://api.openai.com/auth": ["chatgpt_account_id": "workspace-1", "chatgpt_plan_type": "pro"]])
+        let token = try CodexOAuthTokenParser.parse(response(["access_token": access, "id_token": id]), now: now)
+        XCTAssertEqual(token.accountId, "workspace-1")
+        XCTAssertEqual(token.planType, "pro")
+        XCTAssertEqual(token.expireDate, now.addingTimeInterval(3600))
+    }
+
+    func testLegacyClaimsAndEarlierExpiryWin() throws {
+        let access = try jwt(["exp": now.timeIntervalSince1970 + 600, "chatgpt_account_id": "legacy"])
+        let token = try CodexOAuthTokenParser.parse(response(["access_token": access, "expires_in": 3600]), now: now)
+        XCTAssertEqual(token.accountId, "legacy")
+        XCTAssertEqual(token.expireDate, now.addingTimeInterval(600))
+    }
+
+    func testRefreshKeepsIdentityAndRotatedCredentials() throws {
+        let old = CodexTokenStorage(accessToken: "old", refreshToken: "refresh-1", idToken: "id-1",
+                                    expireDate: now, lastRefresh: now, accountId: "account-1", planType: "pro")
+        let retained = try CodexOAuthTokenParser.parse(response(["access_token": "new", "expires_in": 3600]), previous: old, now: now)
+        XCTAssertEqual(retained.refreshToken, "refresh-1")
+        XCTAssertEqual(retained.idToken, "id-1")
+        XCTAssertEqual(retained.accountId, "account-1")
+        XCTAssertEqual(retained.planType, "pro")
+        let rotated = try CodexOAuthTokenParser.parse(response(["access_token": "next", "refresh_token": "refresh-2"]), previous: retained, now: now)
+        XCTAssertEqual(rotated.refreshToken, "refresh-2")
+    }
+
+    func testRefreshCannotChangeAccount() throws {
+        let old = CodexTokenStorage(accessToken: "old", refreshToken: "refresh", idToken: nil,
+                                    expireDate: now, lastRefresh: now, accountId: "account-1", planType: nil)
+        let changed = try jwt(["https://api.openai.com/auth": ["chatgpt_account_id": "account-2"]])
+        XCTAssertThrowsError(try CodexOAuthTokenParser.parse(response(["access_token": changed]), previous: old, now: now))
+    }
+
+    func testExistingKeychainEntryRecoversJWTExpiry() throws {
+        let access = try jwt(["exp": now.timeIntervalSince1970 + 60])
+        let old = CodexTokenStorage(accessToken: access, refreshToken: "refresh", idToken: nil,
+                                    expireDate: nil, lastRefresh: now, accountId: nil, planType: nil)
+        XCTAssertTrue(old.needsRefresh(at: now, buffer: 300))
+        XCTAssertFalse(old.needsRefresh(at: now.addingTimeInterval(-3600), buffer: 300))
+        let opaque = CodexTokenStorage(accessToken: "opaque", refreshToken: "refresh", idToken: nil,
+                                       expireDate: nil, lastRefresh: now, accountId: nil, planType: nil)
+        XCTAssertTrue(opaque.needsRefresh(at: now.addingTimeInterval(8 * 24 * 3600)))
+    }
+
+    func testEmptyAccessTokenRejectedAndIDExpiryNotUsed() throws {
+        XCTAssertThrowsError(try CodexOAuthTokenParser.parse(response(["access_token": "   "]), now: now))
+        let id = try jwt(["exp": 1])
+        let token = try CodexOAuthTokenParser.parse(response(["access_token": "opaque", "id_token": id]), now: now)
+        XCTAssertNil(token.expireDate)
+    }
+
+    func testFormEncodingPreservesPlusAmpersandAndPercent() {
+        let encoded = String(data: CodexOAuthTokenParser.formBody(["code": "a+b&c=1% x", "redirect_uri": "http://localhost:1455/auth/callback"]), encoding: .utf8)
+        XCTAssertEqual(encoded, "code=a%2Bb%26c%3D1%25%20x&redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback")
+    }
+
+    func testStructuredRefreshErrorsDoNotLeakTokensOrDeleteOnWAF() throws {
+        let data = try response(["error": ["code": "refresh_token_reused", "message": "secret-token-do-not-log"]])
+        XCTAssertEqual(CodexOAuthTokenParser.sanitizedErrorCode(data), "refresh_token_reused")
+        XCTAssertTrue(CodexOAuthTokenParser.refreshFailureIsFatal(status: 400, code: "refresh_token_reused"))
+        XCTAssertFalse(CodexOAuthTokenParser.refreshFailureIsFatal(status: 403, code: nil))
+        XCTAssertFalse(CodexOAuthTokenParser.refreshFailureIsFatal(status: 400, code: "invalid_request"))
+        XCTAssertFalse(CodexOAuthTokenParser.refreshFailureIsFatal(status: 503, code: "temporarily_unavailable"))
+    }
+
+    func testCodexCatalogDiscoversAstraAndFutureIDs() throws {
+        // Protocol fixtures, not a claim that this account has these entitlements.
+        let data = try response(["models": [
+            ["slug": "gpt-6-astra", "display_name": "GPT-6 Astra", "visibility": "list", "priority": 1,
+             "context_window": 272000, "max_context_window": 872000, "supported_in_api": false,
+             "input_modalities": ["text", "image"], "supported_reasoning_levels": [["effort": "low"], ["effort": "ultra"]]],
+            ["slug": "future-model-fixture", "display_name": "Future", "visibility": "list", "priority": 2],
+            ["slug": "hidden", "visibility": "hide"],
+            ["slug": "gpt-6-astra", "visibility": "list", "priority": 3],
+        ]])
+        let models = try CodexModelCatalog.parse(data)
+        XCTAssertEqual(models.map(\.id), ["gpt-6-astra", "future-model-fixture"])
+        XCTAssertEqual(models[0].contextWindow, 272000)
+        XCTAssertEqual(models[0].reasoningEfforts, ["low", "ultra"])
+        XCTAssertEqual(models[0].inputModalities, ["text", "image"])
+        XCTAssertNil(models[1].reasoningEfforts)
+        XCTAssertEqual(CodexModelCatalog.modelsURL.host, "chatgpt.com")
+        XCTAssertEqual(URLComponents(url: CodexModelCatalog.modelsURL, resolvingAgainstBaseURL: false)?.queryItems?.first?.value, "0.153.4")
+    }
+
+    func testPublicAPICatalogCannotMasqueradeAsOAuthCatalog() throws {
+        XCTAssertThrowsError(try CodexModelCatalog.parse(response(["data": [["id": "gpt-6-astra"]]])))
+    }
+
+    func testReasoningUsesDeclaredLevelsIncludingUltra() {
+        XCTAssertEqual(CodexModelCatalog.resolvedEffort(requested: "ultra", supported: ["low", "high", "ultra"]), "ultra")
+        XCTAssertEqual(CodexModelCatalog.resolvedEffort(requested: "ultra", supported: ["low", "max"]), "max")
+        XCTAssertEqual(CodexModelCatalog.resolvedEffort(requested: "low", supported: ["medium", "high"]), "medium")
+        XCTAssertEqual(CodexModelCatalog.resolvedEffort(requested: "none", supported: ["low", "medium"]), "low")
+        XCTAssertEqual(CodexModelCatalog.resolvedEffort(requested: "high", supported: nil), "high")
+    }
+}

--- a/src/ios/Providers/LLMTypes.swift
+++ b/src/ios/Providers/LLMTypes.swift
@@ -106,6 +106,9 @@ struct LLMModel: Equatable, Hashable, Identifiable, Sendable, Codable {
     /// configured entries with it. nil decodes cleanly and reads as "not authoritative",
     /// which is the permissive/pass-through direction.
     var effortDeclarationIsAuthoritative: Bool?
+    /// Set only for the Codex service catalog (or its pinned offline fixture).
+    /// Preserve its protocol capabilities when general catalog enrichment runs.
+    var codexCatalogMetadata: Bool?
 
     init(id: String, displayName: String, provider: String, modalityOverride: ModelModality? = nil,
          contextWindow: Int? = nil, maxOutputTokens: Int? = nil,
@@ -253,6 +256,18 @@ struct LLMModel: Equatable, Hashable, Identifiable, Sendable, Codable {
     ]
 
     // MARK: - OpenAI Models
+
+    /// Bundled Codex 0.153.4 fallback. Live account catalog takes precedence.
+    /// https://github.com/openai/codex/pull/42874
+    static let gpt6Astra: LLMModel = {
+        var model = LLMModel(id: "gpt-6-astra", displayName: "GPT-6 Astra", provider: "OpenAI",
+                             modalityOverride: [.textInput, .imageInput, .textOutput],
+                             contextWindow: 272_000, supportsReasoning: true,
+                             reasoningEffortValues: ["low", "medium", "high", "xhigh", "max", "ultra"])
+        model.effortDeclarationIsAuthoritative = true
+        model.codexCatalogMetadata = true
+        return model
+    }()
 
     static let gpt56Sol = LLMModel(
         id: "gpt-5.6-sol",
@@ -416,28 +431,17 @@ struct LLMModel: Equatable, Hashable, Identifiable, Sendable, Codable {
         .codexMini,
     ]
 
-    /// Models available via Codex OAuth (ChatGPT subscription).
-    ///
-    /// [T-codex-oauth-model-prune] The Codex backend rejects a model the
-    /// ChatGPT tier does not carry with
-    /// `HTTP 400 {"detail":"The '<id>' model is not supported when using Codex
-    /// with a ChatGPT account."}` — and that error surfaces as an empty
-    /// assistant turn, so an unusable entry in this picker reads to the user as
-    /// "tool calls are broken" rather than "wrong model". Entries verified 400
-    /// on-device (2026-08-01, real Codex OAuth token) were removed:
-    /// gpt-5.3-codex, gpt-5.3-codex-spark, gpt-5-codex-mini, gpt-5.3, gpt-5.2,
-    /// gpt-5. The survivors match the model set CLIProxyAPI ships for the Codex
-    /// client (`internal/registry/models/codex_client_models.json`), which is
-    /// also gpt-5.6-*/5.5/5.4 only.
-    ///
-    /// Availability is tier-dependent, not absolute — a higher ChatGPT plan may
-    /// carry more. Re-probe before adding anything back; do not restore an id
-    /// from documentation alone.
+    /// Offline seeds for Codex OAuth. The live account-scoped catalog replaces
+    /// these after login/refresh, because availability varies by subscription.
+    /// Astra is pinned to the official Codex 0.153.4 bundled catalog. Existing
+    /// 5.x entries remain as upgrade/offline fallbacks, not a whitelist of future
+    /// supported IDs. Never use the public API-key catalog as OAuth entitlement.
     static let allOpenAICodexOAuth: [LLMModel] = [
+        .gpt6Astra,
         .gpt56Sol, .gpt56Terra, .gpt56Luna,
         .gpt55, .gpt54, .gpt54Mini,
         // gptImage2 is kept: it is an image endpoint, not a Codex chat model,
-        // so the text-model probe above does not apply to it.
+        // so it is preserved separately when the live catalog is refreshed.
         .gptImage2,
     ]
 
@@ -907,7 +911,7 @@ extension LLMModel {
         // "minimal" are OFF-ish tiers handled by the toggle, not the ladder.
         let mapping: [(wire: String, level: ThinkingLevel)] = [
             ("low", .low), ("medium", .medium), ("high", .high),
-            ("xhigh", .xhigh), ("max", .max),
+            ("xhigh", .xhigh), ("max", .max), ("ultra", .ultra),
         ]
         let set = Set(declared.map { $0.lowercased() })
         return mapping.filter { set.contains($0.wire) }.map(\.level)

--- a/src/ios/Providers/ModelEntry.swift
+++ b/src/ios/Providers/ModelEntry.swift
@@ -134,7 +134,7 @@ struct ModelEntry: Identifiable, Codable, Hashable {
     var model: LLMModel {
         guard !overrides.isEmpty else { return baseModel }
         // LLMModel.displayName is a `let`, so rebuild via memberwise init to apply any override.
-        return LLMModel(
+        var effective = LLMModel(
             id: baseModel.id,
             displayName: overrides.displayName ?? baseModel.displayName,
             provider: baseModel.provider,
@@ -142,8 +142,13 @@ struct ModelEntry: Identifiable, Codable, Hashable {
             contextWindow: overrides.contextWindow ?? baseModel.contextWindow,
             maxOutputTokens: overrides.maxOutputTokens ?? baseModel.maxOutputTokens,
             supportsReasoning: overrides.supportsReasoning ?? baseModel.supportsReasoning,
-            interleavedReasoningField: baseModel.interleavedReasoningField
+            interleavedReasoningField: baseModel.interleavedReasoningField,
+            reasoningEffortValues: baseModel.reasoningEffortValues,
+            declaresNoEffortTiers: baseModel.declaresNoEffortTiers
         )
+        effective.effortDeclarationIsAuthoritative = baseModel.effortDeclarationIsAuthoritative
+        effective.codexCatalogMetadata = baseModel.codexCatalogMetadata
+        return effective
     }
 
     init(

--- a/src/ios/Providers/ModelsDevAPI.swift
+++ b/src/ios/Providers/ModelsDevAPI.swift
@@ -302,6 +302,10 @@ enum ModelsDevAPI {
     private static func applyDevData(
         to model: LLMModel, from devModel: ModelsDevModel, authoritative: Bool = false
     ) -> LLMModel {
+        // The account-scoped Codex protocol catalog is authoritative. Replacing
+        // its new effort tiers/context with a lagging global catalog caused new
+        // models to disappear or issue invalid requests after enrichment.
+        if model.codexCatalogMetadata == true { return model }
         var result = model
 
         // Modality: models.dev is the source of truth — always apply when available.

--- a/src/ios/Providers/OpenAI/OAuth/CodexModelCatalog.swift
+++ b/src/ios/Providers/OpenAI/OAuth/CodexModelCatalog.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Wire schema for the account-scoped Codex catalog, not the public /v1/models
+/// API. Ignore unknown fields so future models do not require an app release.
+enum CodexModelCatalog {
+    // Protocol compatibility baseline verified against OpenAI's 0.153.4 release.
+    // https://github.com/openai/codex/releases/tag/rust-v0.153.4
+    static let clientVersion = "0.153.4"
+    static let modelsURL = URL(string: "https://chatgpt.com/backend-api/codex/models?client_version=\(clientVersion)")!
+
+    struct Entry: Equatable, Sendable {
+        let id: String
+        let displayName: String
+        let contextWindow: Int?
+        let inputModalities: [String]?
+        let reasoningEfforts: [String]?
+        let priority: Int
+    }
+
+    static func parse(_ data: Data) throws -> [Entry] {
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let models = object["models"] as? [[String: Any]] else {
+            throw NSError(domain: "CodexModelCatalog", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Missing Codex models array"])
+        }
+        var seen = Set<String>()
+        return models.compactMap { model -> Entry? in
+            guard let id = model["slug"] as? String, !id.isEmpty,
+                  model["visibility"] as? String == "list", seen.insert(id).inserted else { return nil }
+            // supported_in_api is about API-key availability, not this user's
+            // ChatGPT OAuth entitlement; never use it to filter this catalog.
+            let name = model["display_name"] as? String
+            let rawEfforts = model["supported_reasoning_levels"] as? [[String: Any]]
+            let efforts = rawEfforts.map { levels in
+                var seenEfforts = Set<String>()
+                return levels.compactMap { ($0["effort"] as? String)?.lowercased() }
+                    .filter { !$0.isEmpty && seenEfforts.insert($0).inserted }
+            }
+            let context = (model["context_window"] as? Int) ?? (model["max_context_window"] as? Int)
+            return Entry(
+                id: id,
+                displayName: name.flatMap { $0.isEmpty ? nil : $0 } ?? id,
+                contextWindow: context.flatMap { $0 > 0 ? $0 : nil },
+                inputModalities: model["input_modalities"] as? [String],
+                reasoningEfforts: efforts,
+                priority: model["priority"] as? Int ?? Int.max
+            )
+        }.sorted { $0.priority == $1.priority ? $0.id < $1.id : $0.priority < $1.priority }
+    }
+
+    /// Choose a valid level without silently turning the model's mandatory
+    /// reasoning off. Preserve new server effort strings if requested exactly.
+    static func resolvedEffort(requested: String, supported: [String]?) -> String {
+        guard let supported, !supported.isEmpty else { return requested }
+        if supported.contains(requested) { return requested }
+        let order = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"]
+        guard let rank = order.firstIndex(of: requested) else { return supported[0] }
+        let known = supported.compactMap { value -> (String, Int)? in
+            guard let index = order.firstIndex(of: value) else { return nil }
+            return (value, index)
+        }.sorted { $0.1 < $1.1 }
+        return known.last(where: { $0.1 <= rank })?.0 ?? known.first?.0 ?? supported[0]
+    }
+}

--- a/src/ios/Providers/OpenAI/OAuth/CodexOAuthManager.swift
+++ b/src/ios/Providers/OpenAI/OAuth/CodexOAuthManager.swift
@@ -50,14 +50,17 @@ final class CodexOAuthManager: NSObject, ObservableObject {
     }
 
     func accountId(instanceId: String) -> String? {
-        ProviderKeychainHelper.loadOAuthToken(instanceId: instanceId, as: CodexTokenStorage.self)?.accountId
+        ProviderKeychainHelper.loadOAuthToken(instanceId: instanceId, as: CodexTokenStorage.self)?.resolvedAccountId
     }
 
     func planType(instanceId: String) -> String? {
-        ProviderKeychainHelper.loadOAuthToken(instanceId: instanceId, as: CodexTokenStorage.self)?.planType
+        ProviderKeychainHelper.loadOAuthToken(instanceId: instanceId, as: CodexTokenStorage.self)?.resolvedPlanType
     }
 
     func login(instanceId: String) async throws {
+        guard !isAuthenticating else {
+            throw LLMError.providerError(message: "An OpenAI login is already in progress")
+        }
         logger.info("=== Codex OAuth login started (instance: \(instanceId)) ===")
         // Defensive cleanup: stop any leftover server from a previous failed attempt
         callbackServer?.stop()
@@ -73,7 +76,7 @@ final class CodexOAuthManager: NSObject, ObservableObject {
 
         let (verifier, challenge) = generatePKCE()
         let state = generateState()
-        logger.info("PKCE generated — verifier length: \(verifier.count), challenge: \(challenge.prefix(16))...")
+        logger.info("PKCE generated")
 
         // 1. Start local HTTP server
         let server = OAuthCallbackServer(port: callbackPort, callbackPath: "/auth/callback")
@@ -96,7 +99,7 @@ final class CodexOAuthManager: NSObject, ObservableObject {
             URLQueryItem(name: "originator", value: "codex_cli_rs"),
         ]
         let authorizationURL = components.url!
-        logger.info("Authorization URL: \(authorizationURL.absoluteString)")
+        logger.info("Opening OpenAI authorization page")
 
         // 3. Open in-app Safari
         presentSafariViewController(url: authorizationURL)
@@ -131,13 +134,15 @@ final class CodexOAuthManager: NSObject, ObservableObject {
             throw LLMError.invalidAPIKey(detail: "Codex: no OAuth token found for instance \(instanceId)")
         }
 
-        let needsRefresh = storage.refreshToken != nil
-            && (storage.expireDate.map({ $0.timeIntervalSinceNow <= refreshBuffer }) ?? false)
+        let needsRefresh = storage.needsRefresh(buffer: refreshBuffer)
 
         if needsRefresh {
             storage = try await refreshTokenGuarded(instanceId: instanceId, existingStorage: storage)
         }
 
+        guard !storage.isExpired else {
+            throw LLMError.invalidAPIKey(detail: "Codex: token expired; sign in again")
+        }
         guard let token = Optional(storage.accessToken), !token.isEmpty else {
             throw LLMError.invalidAPIKey(detail: "Codex: access token is empty for instance \(instanceId)")
         }
@@ -153,10 +158,10 @@ final class CodexOAuthManager: NSObject, ObservableObject {
     /// the precise `invalid_grant` / `refresh_token_reused` codes + auth statuses
     /// cover real revocation without it.
     private func isRefreshTokenInvalid(_ error: LLMError) -> Bool {
-        OAuthRefreshErrorClassifier.isTokenInvalid(
-            error,
-            fatalErrorCodes: ["invalid_grant", "invalid_token", "invalid_request",
-                              "unauthorized_client", "refresh_token_reused"]
+        guard case .providerError(let message) = error else { return false }
+        return CodexOAuthTokenParser.refreshFailureIsFatal(
+            status: OAuthRefreshErrorClassifier.parseStatus(from: message),
+            code: OAuthRefreshErrorClassifier.parseErrorCode(fromBody: message)
         )
     }
 
@@ -168,12 +173,25 @@ final class CodexOAuthManager: NSObject, ObservableObject {
         do {
             return try await refreshSingleFlight.run(instanceId: instanceId) { [weak self] in
                 guard let self else { throw LLMError.providerError(message: "OAuth manager deallocated") }
+                guard let before = ProviderKeychainHelper.loadOAuthToken(instanceId: instanceId, as: CodexTokenStorage.self) else {
+                    throw CancellationError()
+                }
+                guard before == existingStorage else { return before }
                 logger.info("Refreshing Codex token on-demand (instance: \(instanceId))...")
-                let refreshed = try await self.performRefresh(refreshToken: staleRefreshToken)
+                let refreshed = try await self.performRefresh(existingStorage: existingStorage)
+                // A logout or new login during the network round trip wins.
+                guard let current = ProviderKeychainHelper.loadOAuthToken(instanceId: instanceId, as: CodexTokenStorage.self) else {
+                    throw CancellationError()
+                }
+                guard current == existingStorage else { return current }
                 ProviderKeychainHelper.saveOAuthToken(refreshed, instanceId: instanceId)
                 return refreshed
             }
         } catch {
+            if error is CancellationError { throw error }
+            guard ProviderKeychainHelper.loadOAuthToken(instanceId: instanceId, as: CodexTokenStorage.self) != nil else {
+                throw LLMError.invalidAPIKey(detail: "Codex: signed out during refresh")
+            }
             return try OAuthRefreshCoordinator.resolveAfterRefreshFailure(
                 providerName: "Codex",
                 staleRefreshToken: staleRefreshToken,
@@ -248,45 +266,32 @@ final class CodexOAuthManager: NSObject, ObservableObject {
         return try await postTokenRequest(body: body, context: "Token exchange")
     }
 
-    private func performRefresh(refreshToken: String) async throws -> CodexTokenStorage {
+    private func performRefresh(existingStorage: CodexTokenStorage) async throws -> CodexTokenStorage {
+        guard let refreshToken = existingStorage.refreshToken, !refreshToken.isEmpty else {
+            throw LLMError.invalidAPIKey(detail: "Codex: missing refresh token")
+        }
         let body: [String: String] = [
             "grant_type": "refresh_token",
             "client_id": clientID,
             "refresh_token": refreshToken,
-            "scope": scopes,
         ]
-
-        var storage = try await postTokenRequest(body: body, context: "Token refresh")
-        // OpenAI may not return a new refresh token on every refresh;
-        // preserve the existing one so subsequent refreshes keep working.
-        if storage.refreshToken == nil {
-            storage = CodexTokenStorage(
-                accessToken: storage.accessToken,
-                refreshToken: refreshToken,
-                idToken: storage.idToken,
-                expireDate: storage.expireDate,
-                lastRefresh: storage.lastRefresh,
-                accountId: storage.accountId,
-                planType: storage.planType
-            )
-        }
-        return storage
+        return try await postTokenRequest(body: body, context: "Token refresh", previous: existingStorage)
     }
 
-    private func postTokenRequest(body: [String: String], context: String) async throws -> CodexTokenStorage {
+    private func postTokenRequest(body: [String: String], context: String, previous: CodexTokenStorage? = nil) async throws -> CodexTokenStorage {
         var request = URLRequest(url: URL(string: tokenURL)!)
         request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        let jsonData = try JSONSerialization.data(withJSONObject: body)
-        request.httpBody = jsonData
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 30
+        request.httpBody = CodexOAuthTokenParser.formBody(body)
 
         logger.info("\(context) POST \(self.tokenURL)")
 
         let (data, response) = try await URLSession.shared.data(for: request)
         let http = response as? HTTPURLResponse
         let statusCode = http?.statusCode ?? -1
-        let responseBody = String(data: data, encoding: .utf8) ?? "<binary>"
+        let responseBody = "{\"error\":\"\(CodexOAuthTokenParser.sanitizedErrorCode(data))\"}"
 
         logger.info("\(context) Response status: \(statusCode)")
 
@@ -300,66 +305,11 @@ final class CodexOAuthManager: NSObject, ObservableObject {
             throw LLMError.providerError(message: "\(context) failed: " + OAuthRefreshErrorClassifier.makeErrorMessage(status: statusCode, body: responseBody))
         }
 
-        return try parseTokenResponse(data)
+        return try CodexOAuthTokenParser.parse(data, previous: previous)
     }
 
-    private func parseTokenResponse(_ data: Data) throws -> CodexTokenStorage {
-        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
-
-        guard let accessToken = json["access_token"] as? String else {
-            throw LLMError.decodingError(underlying: NSError(domain: "OAuth", code: -1,
-                userInfo: [NSLocalizedDescriptionKey: "Missing access_token"]))
-        }
-
-        let refreshToken = json["refresh_token"] as? String
-        let expiresIn = json["expires_in"] as? TimeInterval
-        let expireDate = expiresIn.map { Date().addingTimeInterval($0) }
-        let idToken = json["id_token"] as? String
-
-        // Parse JWT id_token to extract account info
-        var extractedAccountId: String?
-        var extractedPlanType: String?
-        if let idToken {
-            let claims = Self.decodeJWTPayload(idToken)
-            extractedAccountId = claims?["chatgpt_account_id"] as? String
-            extractedPlanType = claims?["chatgpt_plan_type"] as? String
-            if let aid = extractedAccountId {
-                logger.info("Extracted accountId: \(aid)")
-            }
-            if let plan = extractedPlanType {
-                logger.info("Extracted planType: \(plan)")
-            }
-        }
-
-        return CodexTokenStorage(
-            accessToken: accessToken,
-            refreshToken: refreshToken,
-            idToken: idToken,
-            expireDate: expireDate,
-            lastRefresh: Date(),
-            accountId: extractedAccountId,
-            planType: extractedPlanType
-        )
-    }
-
-    // MARK: - JWT Decode
-
-    /// Decode the payload (segment[1]) of a JWT without signature verification.
     static func decodeJWTPayload(_ jwt: String) -> [String: Any]? {
-        let segments = jwt.split(separator: ".")
-        guard segments.count >= 2 else { return nil }
-
-        var base64 = String(segments[1])
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        // Pad to multiple of 4
-        let remainder = base64.count % 4
-        if remainder > 0 {
-            base64 += String(repeating: "=", count: 4 - remainder)
-        }
-
-        guard let data = Data(base64Encoded: base64) else { return nil }
-        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        CodexOAuthTokenParser.decodeJWTPayload(jwt)
     }
 
     // MARK: - In-App Safari
@@ -373,23 +323,6 @@ final class CodexOAuthManager: NSObject, ObservableObject {
         let vc = SFSafariViewController(url: url)
         topVC.present(vc, animated: true)
         self.safariVC = vc
-    }
-}
-
-// MARK: - Token Storage Model
-
-struct CodexTokenStorage: Codable {
-    let accessToken: String
-    let refreshToken: String?
-    let idToken: String?
-    let expireDate: Date?
-    let lastRefresh: Date?
-    let accountId: String?
-    let planType: String?
-
-    var isExpired: Bool {
-        guard let expire = expireDate else { return false }
-        return expire < Date()
     }
 }
 

--- a/src/ios/Providers/OpenAI/OAuth/CodexOAuthToken.swift
+++ b/src/ios/Providers/OpenAI/OAuth/CodexOAuthToken.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+/// The persisted schema stays compatible with existing Minis keychain entries.
+struct CodexTokenStorage: Codable, Sendable, Equatable {
+    let accessToken: String
+    let refreshToken: String?
+    let idToken: String?
+    let expireDate: Date?
+    let lastRefresh: Date?
+    let accountId: String?
+    let planType: String?
+
+    /// Older versions saved nil when the endpoint omitted expires_in, even if
+    /// the access token contained exp. Recover that expiry without a migration.
+    var effectiveExpiry: Date? {
+        expireDate ?? CodexOAuthTokenParser.expiry(of: accessToken)
+    }
+
+    var resolvedAccountId: String? {
+        accountId ?? CodexOAuthTokenParser.accountInfo(idToken: idToken, accessToken: accessToken).id
+    }
+
+    var resolvedPlanType: String? {
+        planType ?? CodexOAuthTokenParser.accountInfo(idToken: idToken, accessToken: accessToken).plan
+    }
+
+    var isExpired: Bool {
+        effectiveExpiry.map { $0 <= Date() } ?? false
+    }
+
+    func needsRefresh(at now: Date = Date(), buffer: TimeInterval = 300) -> Bool {
+        guard let refreshToken, !refreshToken.isEmpty else { return false }
+        if let expiry = effectiveExpiry { return expiry.timeIntervalSince(now) <= buffer }
+        // Opaque tokens have no readable exp. Do not silently keep them forever.
+        return lastRefresh.map { now.timeIntervalSince($0) >= 8 * 24 * 3600 } ?? true
+    }
+}
+
+enum CodexOAuthTokenParser {
+    private static let authClaim = "https://api.openai.com/auth"
+
+    static func parse(_ data: Data, previous: CodexTokenStorage? = nil, now: Date = Date()) throws -> CodexTokenStorage {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let access = nonEmpty(json["access_token"] as? String) else {
+            throw NSError(domain: "CodexOAuth", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "Missing or empty access_token"])
+        }
+        let newIDToken = nonEmpty(json["id_token"] as? String)
+        let info = accountInfo(idToken: newIDToken, accessToken: access)
+        if let oldID = previous?.resolvedAccountId, let newID = info.id, oldID != newID {
+            throw NSError(domain: "CodexOAuth", code: 2,
+                          userInfo: [NSLocalizedDescriptionKey: "OAuth refresh changed account; sign in again"])
+        }
+        let expiresIn = (json["expires_in"] as? NSNumber)?.doubleValue
+        let reportedExpiry = expiresIn.flatMap { $0.isFinite ? now.addingTimeInterval(max(0, $0)) : nil }
+        // If both are present, honor the earlier expiry. Never use the ID-token
+        // expiry to schedule refresh of the separate access token.
+        let expiry = [reportedExpiry, Self.expiry(of: access)].compactMap { $0 }.min()
+        return CodexTokenStorage(
+            accessToken: access,
+            refreshToken: nonEmpty(json["refresh_token"] as? String) ?? previous?.refreshToken,
+            idToken: newIDToken ?? previous?.idToken,
+            expireDate: expiry,
+            lastRefresh: now,
+            accountId: info.id ?? previous?.resolvedAccountId,
+            planType: info.plan ?? previous?.resolvedPlanType
+        )
+    }
+
+    /// These claims are metadata from the TLS token response, not a local
+    /// signature check or an authorization decision. The service validates the
+    /// bearer token on every API call; decoded claims never grant permissions.
+    static func decodeJWTPayload(_ jwt: String) -> [String: Any]? {
+        let segments = jwt.split(separator: ".", omittingEmptySubsequences: false)
+        guard segments.count == 3, !segments[1].isEmpty else { return nil }
+        var base64 = String(segments[1]).replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+        guard let data = Data(base64Encoded: base64) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    static func expiry(of token: String) -> Date? {
+        guard let exp = decodeJWTPayload(token)?["exp"] as? NSNumber,
+              exp.doubleValue.isFinite else { return nil }
+        return Date(timeIntervalSince1970: exp.doubleValue)
+    }
+
+    static func accountInfo(idToken: String?, accessToken: String) -> (id: String?, plan: String?) {
+        var id: String?
+        var plan: String?
+        for token in [idToken, accessToken].compactMap({ $0 }) {
+            guard let claims = decodeJWTPayload(token) else { continue }
+            let namespaced = claims[authClaim] as? [String: Any] ?? [:]
+            id = id ?? nonEmpty(namespaced["chatgpt_account_id"] as? String)
+                ?? nonEmpty(claims["chatgpt_account_id"] as? String)
+            plan = plan ?? nonEmpty(namespaced["chatgpt_plan_type"] as? String)
+                ?? nonEmpty(claims["chatgpt_plan_type"] as? String)
+        }
+        return (id, plan)
+    }
+
+    static func formBody(_ values: [String: String]) -> Data {
+        let allowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+        return Data(values.sorted { $0.key < $1.key }.map { key, value in
+            "\(key.addingPercentEncoding(withAllowedCharacters: allowed)!)=\(value.addingPercentEncoding(withAllowedCharacters: allowed)!)"
+        }.joined(separator: "&").utf8)
+    }
+
+    /// Keep only a structured error identifier. OAuth error descriptions may
+    /// echo a submitted code/token and must not reach durable logs or the UI.
+    static func sanitizedErrorCode(_ data: Data) -> String {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return "oauth_error" }
+        let nested = json["error"] as? [String: Any]
+        let raw = (json["error"] as? String) ?? (nested?["code"] as? String) ?? "oauth_error"
+        let known: Set<String> = ["invalid_grant", "invalid_token", "refresh_token_reused", "refresh_token_expired",
+                                  "refresh_token_invalidated", "invalid_request", "invalid_client", "unauthorized_client",
+                                  "access_denied", "temporarily_unavailable", "server_error", "rate_limit_exceeded"]
+        return known.contains(raw.lowercased()) ? raw.lowercased() : "oauth_error"
+    }
+
+    static func refreshFailureIsFatal(status: Int?, code: String?) -> Bool {
+        let invalidTokens: Set<String> = ["invalid_grant", "invalid_token", "refresh_token_reused",
+                                          "refresh_token_expired", "refresh_token_invalidated"]
+        // 400 can be a malformed request and 403 can be a proxy/WAF rejection.
+        // Neither, alone, proves the refresh credential was revoked.
+        return status == 401 || code.map { invalidTokens.contains($0) } == true
+    }
+
+    private static func nonEmpty(_ text: String?) -> String? {
+        guard let text, !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+        return text
+    }
+}

--- a/src/ios/Providers/OpenAI/OpenAIAgentProvider.swift
+++ b/src/ios/Providers/OpenAI/OpenAIAgentProvider.swift
@@ -470,6 +470,19 @@ final class OpenAIAgentProvider: AgentProvider {
         if provider.isMistral {
             // No reasoning key, and reasoningRequested stays false so the
             // encrypted-reasoning include below is skipped too.
+        } else if isCodexOAuth {
+            // The authenticated Codex catalog owns its effort tiers. Preserve
+            // newly advertised values such as "ultra" instead of applying the
+            // API-compatible mapping below, then resolve against this account's
+            // model declaration. Thinking off retains the Codex low-effort
+            // fallback, adjusted when this model does not accept "low".
+            let requestedEffort = thinkingLevel.isEnabled ? thinkingLevel.rawValue : "low"
+            let effort = CodexModelCatalog.resolvedEffort(
+                requested: requestedEffort,
+                supported: model.reasoningEffortValues
+            )
+            body["reasoning"] = ["effort": effort, "summary": "auto"]
+            reasoningRequested = true
         } else if thinkingLevel.isEnabled, let effort = Self.reasoningEffort(for: model, level: thinkingLevel) {
             // `summary: "auto"` opts in to streaming the human-readable
             // reasoning summary (delivered as `response.reasoning_summary_text.delta`
@@ -478,11 +491,6 @@ final class OpenAIAgentProvider: AgentProvider {
             // token count. Safe to send to every Responses-flavor endpoint:
             // OpenAI ignores unknown variants and falls back to "auto"-equiv.
             body["reasoning"] = ["effort": effort, "summary": "auto"]
-            reasoningRequested = true
-        } else if isCodexOAuth {
-            // Codex requires a `reasoning` object on every request — fall back
-            // to "low" when the user has thinking off.
-            body["reasoning"] = ["effort": "low", "summary": "auto"]
             reasoningRequested = true
         } else if model.supportsReasoning ?? false,
                   let offEffort = Self.explicitOffEffort(for: provider, model: model, level: thinkingLevel) {

--- a/src/ios/Providers/OpenAI/OpenAIModelsAPI.swift
+++ b/src/ios/Providers/OpenAI/OpenAIModelsAPI.swift
@@ -37,12 +37,48 @@ enum OpenAIModelsAPI {
         return models
     }
 
-    /// OAuth mode: return built-in Codex model list enriched with models.dev data.
-    /// OAuth tokens cannot call /v1/models, so we use the static list.
-    static func fetchModelsOAuth() -> [LLMModel] {
-        let enriched = ModelsDevAPI.enrichModels(LLMModel.allOpenAICodexOAuth)
-        logger.info("Using built-in Codex OAuth model list (\(enriched.count) models, enriched)")
-        return enriched
+    /// ChatGPT OAuth has its own account-scoped catalog. The public API catalog
+    /// cannot tell us which new Codex models this account may use.
+    static func fetchModelsOAuth(accessToken: String, accountId: String?, instanceId: String,
+                                 forceRefresh: Bool = false) async throws -> [LLMModel] {
+        let cacheKey = "codex-models-v1:\(instanceId):\(accountId ?? "unknown"):\(CodexModelCatalog.clientVersion)"
+        if !forceRefresh, let cached = OpenAIModelsCache.load(credential: cacheKey, ttl: 3600) {
+            return cached
+        }
+        var request = URLRequest(url: CodexModelCatalog.modelsURL)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("OpenMinis-iOS (Codex protocol \(CodexModelCatalog.clientVersion))", forHTTPHeaderField: "User-Agent")
+        if let accountId { request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id") }
+        request.timeoutInterval = 30
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(status) else {
+            if status == 401 || status == 403 {
+                throw LLMError.invalidAPIKey(detail: "Codex model catalog HTTP \(status); sign in again or check account access")
+            }
+            throw LLMError.providerError(message: "Codex model catalog HTTP \(status)")
+        }
+        var models = try CodexModelCatalog.parse(data).map { entry in
+            var modalities: ModelModality = [.textInput, .textOutput]
+            if entry.inputModalities?.contains("image") == true { modalities.insert(.imageInput) }
+            var model = LLMModel(id: entry.id, displayName: entry.displayName, provider: "OpenAI",
+                                 modalityOverride: modalities, contextWindow: entry.contextWindow,
+                                 supportsReasoning: entry.reasoningEfforts.map { !$0.isEmpty },
+                                 reasoningEffortValues: entry.reasoningEfforts,
+                                 declaresNoEffortTiers: entry.reasoningEfforts.map { $0.isEmpty })
+            model.effortDeclarationIsAuthoritative = entry.reasoningEfforts == nil ? nil : true
+            model.codexCatalogMetadata = true
+            return model
+        }
+        // Keep live reasoning/context authoritative over third-party catalogs.
+        guard !models.isEmpty else {
+            throw LLMError.providerError(message: "Codex returned no available models for this account")
+        }
+        // This existing image-tool shortcut is not a text catalog entry.
+        if !models.contains(where: { $0.id == LLMModel.gptImage2.id }) { models.append(.gptImage2) }
+        OpenAIModelsCache.save(models, credential: cacheKey)
+        return models
     }
 
     private static func performFetch(_ request: URLRequest, filterOpenAIOnly: Bool = true) async throws -> [LLMModel] {
@@ -185,7 +221,7 @@ private enum OpenAIModelsCache {
         cacheDir.appendingPathComponent(cacheKey(for: credential) + ".json")
     }
 
-    static func load(credential: String) -> [LLMModel]? {
+    static func load(credential: String, ttl: TimeInterval = 7 * 24 * 3600) -> [LLMModel]? {
         let file = cacheFile(for: credential)
         guard let data = try? Data(contentsOf: file),
               let entry = try? JSONDecoder().decode(Entry.self, from: data),

--- a/src/ios/Providers/OpenAI/OpenAIProvider.swift
+++ b/src/ios/Providers/OpenAI/OpenAIProvider.swift
@@ -88,7 +88,7 @@ private func makeStreamingSession() -> URLSession {
 ///   - API Key: Standard Chat Completions API at api.openai.com
 ///   - OAuth (Codex): Responses API at chatgpt.com/backend-api/codex/responses
 final class OpenAIProvider: LLMProvider {
-    static let codexClientVersion = "0.144.1"
+    static let codexClientVersion = CodexModelCatalog.clientVersion
 
     /// [T-codex-fast-mode] UserDefaults key for the Codex Fast Mode toggle.
     /// Read at request-build time (not cached at init) so flipping the "..."
@@ -807,7 +807,7 @@ final class OpenAIProvider: LLMProvider {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
             request.setValue(Self.codexClientVersion, forHTTPHeaderField: "Version")
             request.setValue("responses=experimental", forHTTPHeaderField: "Openai-Beta")
-            request.setValue("codex_cli_rs/\(Self.codexClientVersion) (iOS; arm64)", forHTTPHeaderField: "User-Agent")
+            request.setValue("OpenMinis-iOS (Codex protocol \(Self.codexClientVersion); arm64)", forHTTPHeaderField: "User-Agent")
             request.setValue("codex_cli_rs", forHTTPHeaderField: "Originator")
             if let accountId = codexAccountId {
                 request.setValue(accountId, forHTTPHeaderField: "Chatgpt-Account-Id")
@@ -1109,7 +1109,7 @@ final class OpenAIProvider: LLMProvider {
         if isCodexOAuth {
             request.setValue(Self.codexClientVersion, forHTTPHeaderField: "Version")
             request.setValue("responses=experimental", forHTTPHeaderField: "Openai-Beta")
-            request.setValue("codex_cli_rs/\(Self.codexClientVersion) (iOS; arm64)", forHTTPHeaderField: "User-Agent")
+            request.setValue("OpenMinis-iOS (Codex protocol \(Self.codexClientVersion); arm64)", forHTTPHeaderField: "User-Agent")
             request.setValue("codex_cli_rs", forHTTPHeaderField: "Originator")
             if let accountId = codexAccountId {
                 request.setValue(accountId, forHTTPHeaderField: "Chatgpt-Account-Id")
@@ -1140,7 +1140,7 @@ final class OpenAIProvider: LLMProvider {
         // Include encrypted reasoning only for Codex OAuth
         if isCodexOAuth {
             body["include"] = ["reasoning.encrypted_content"]
-            body["reasoning"] = ["effort": "low"]
+            body["reasoning"] = ["effort": CodexModelCatalog.resolvedEffort(requested: "low", supported: model.reasoningEffortValues)]
         }
         // [T-codex-fast-mode] User-toggled Fast Mode ("..." menu). Wire value
         // verified against codex_cli_rs source: ServiceTier::Fast.

--- a/src/ios/Providers/ProviderConfigStore.swift
+++ b/src/ios/Providers/ProviderConfigStore.swift
@@ -814,8 +814,8 @@ final class ProviderConfigStore: ObservableObject {
             }
             config.modelEntries.append(contentsOf: entries)
             logger.info("[ModelList] addInstance (OAuth): instance=\(instance.label) seeded \(entries.count) built-in entries: [\(entries.map { $0.baseModel.id }.prefix(10).joined(separator: ","))]")
-            // Manual OAuth tokens and OpenRouter OAuth can fetch models from the API
-            if hasManualToken || instance.providerType == .openRouter {
+            // Refresh Codex's account catalog immediately after login too.
+            if hasManualToken || instance.providerType == .openRouter || instance.providerType == .openAI {
                 Task { await refreshModels(for: instance) }
             }
         } else if !VoiceProviderTemplate.mockEntries(for: instance).isEmpty {
@@ -2506,7 +2506,9 @@ final class ProviderConfigStore: ObservableObject {
         // [T-mimo-shadow-voice] No longer skipped for "voice-only" providers —
         // audio-modality template seed entries survive replaceEntries.
         let hasCustomModels = config.modelEntries.contains { $0.providerInstanceId == instance.id && $0.isCustom }
-        if hasCustomModels {
+        let usesLiveCodexCatalog = instance.providerType == .openAI && instance.credentialType == .oauth
+            && ProviderKeychainHelper.loadOAuthString(instanceId: instance.id, account: "manual-oauth-token") == nil
+        if hasCustomModels && !usesLiveCodexCatalog {
             logger.info("[ModelList] autoRefreshModels (DAILY): instance=\(instance.label) SKIP — user has custom models")
             return
         }
@@ -2565,7 +2567,9 @@ final class ProviderConfigStore: ObservableObject {
     /// Called on first daily launch to keep model lists up-to-date.
     /// Skips instances where the user has manually added custom models.
     func refreshAllModelsIfNeeded() {
-        let key = "lastModelsRefreshDate"
+        // Refresh once on upgrading from the static Codex whitelist, even if
+        // the old build already refreshed today. Custom entries survive merge.
+        let key = "lastModelsRefreshDate.codex-live-v1"
         let lastRefresh = UserDefaults.standard.object(forKey: key) as? Date
         let calendar = Calendar.current
         let lastStr = lastRefresh.map { ISO8601DateFormatter().string(from: $0) } ?? "nil"
@@ -2660,7 +2664,10 @@ final class ProviderConfigStore: ObservableObject {
             if let manualToken = ProviderKeychainHelper.loadOAuthString(instanceId: instance.id, account: "manual-oauth-token") {
                 return try await OpenAIModelsAPI.fetchModels(apiKey: manualToken, baseURL: customBase, appendV1Suffix: appendV1, forceRefresh: forceRefresh, userAgent: ua)
             }
-            return OpenAIModelsAPI.fetchModelsOAuth()
+            let token = try await CodexOAuthManager.shared.validAccessToken(instanceId: instance.id)
+            let accountId = CodexOAuthManager.shared.accountId(instanceId: instance.id)
+            return try await OpenAIModelsAPI.fetchModelsOAuth(accessToken: token, accountId: accountId,
+                                                             instanceId: instance.id, forceRefresh: forceRefresh)
         case (.antigravity, .apiKey):
             // Antigravity only supports OAuth
             return ModelsDevAPI.enrichModels(AntigravityModelsAPI.fetchModelsBuiltIn())
@@ -2825,6 +2832,13 @@ final class ProviderConfigStore: ObservableObject {
     static func fetchModelsWithFallback(_ instance: ProviderInstance, forceRefresh: Bool = false) async throws -> ModelFetchResult {
         var warnings: [String] = []
         let isThirdParty = isThirdPartyOpenAICompat(instance)
+        // Public API/models.dev listings do not establish ChatGPT entitlement.
+        // Preserve saved models on catalog failure and expose the actual error.
+        if instance.providerType == .openAI, instance.credentialType == .oauth,
+           ProviderKeychainHelper.loadOAuthString(instanceId: instance.id, account: "manual-oauth-token") == nil {
+            let models = try await fetchModelsForInstance(instance, forceRefresh: forceRefresh)
+            return ModelFetchResult(models: models, source: "codex-account", warnings: [])
+        }
 
         // Step 1: Try /v1/models API
         do {

--- a/src/ios/ShareExtension/ShareViewController.swift
+++ b/src/ios/ShareExtension/ShareViewController.swift
@@ -11,6 +11,16 @@ class ShareViewController: UIViewController {
         view.backgroundColor = .clear
         NSLog("[ShareExt] viewDidLoad — starting processing")
 
+        guard SharedContainerStore.isAppGroupAvailable else {
+            NSLog("[ShareExt] App Group unavailable; cancelling share without reporting delivery")
+            extensionContext?.cancelRequest(withError: NSError(
+                domain: NSCocoaErrorDomain,
+                code: NSFileWriteNoPermissionError,
+                userInfo: [NSLocalizedDescriptionKey: "Sharing is unavailable because this signing configuration cannot access the shared container."]
+            ))
+            return
+        }
+
         Task { @MainActor in
             let vm = ShareViewModel()
             let items = (extensionContext?.inputItems as? [NSExtensionItem]) ?? []

--- a/src/ios/Shared/SharedContainerStore.swift
+++ b/src/ios/Shared/SharedContainerStore.swift
@@ -5,16 +5,24 @@ import Foundation
 enum SharedContainerStore {
     static let appGroupID = "group.com.openminis.app"
 
+    /// The actual shared container. A private app directory is never a
+    /// substitute for transferring data to an extension.
+    static var containerURL: URL? {
+        FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupID)
+    }
+
+    static var isAppGroupAvailable: Bool { containerURL != nil }
+
     private static let pendingShareKey = "pendingShare"
 
     static var sharedDefaults: UserDefaults? {
-        UserDefaults(suiteName: appGroupID)
+        guard isAppGroupAvailable else { return nil }
+        return UserDefaults(suiteName: appGroupID)
     }
 
     /// Directory in the shared container for transferring attachment files.
     static var sharedFileDirectory: URL? {
-        FileManager.default
-            .containerURL(forSecurityApplicationGroupIdentifier: appGroupID)?
+        containerURL?
             .appendingPathComponent("ShareExtension", isDirectory: true)
     }
 

--- a/src/ios/Views/ContentView.swift
+++ b/src/ios/Views/ContentView.swift
@@ -864,6 +864,7 @@ private func probeRowHeight(_ h: CGFloat, _ tag: String) {
 /// Sheets triggered from the toolbar menu, consolidated into a single `.sheet(item:)`.
 enum ToolSheet: String, Identifiable {
     case settings
+    case team
     case rootfsManagement
     case browser
     case browserManagement
@@ -1042,6 +1043,7 @@ struct ContentView: View {
     @State private var showAlarmList = false
     @State private var hasAlarms = false
     @State private var activeToolSheet: ToolSheet?
+    @State private var pendingTeamSessionID: String?
     #if DEBUG
     // [debug] Keep the screen awake (disable the idle/auto-lock timer) while the
     // app is in the foreground. Memory-only on purpose — NOT persisted, so it
@@ -1443,10 +1445,21 @@ struct ContentView: View {
         .sheet(isPresented: $showAlarmList, onDismiss: { fetchAlarmsIfNeeded() }) {
             AlarmListView()
         }
-        .sheet(item: $activeToolSheet) { sheet in
+        .sheet(item: $activeToolSheet, onDismiss: {
+            if let sessionID = pendingTeamSessionID {
+                pendingTeamSessionID = nil
+                refreshSessionList()
+                switchToSession(sessionID)
+            }
+        }) { sheet in
             switch sheet {
             case .settings:
                 SettingsSheet(showTerminal: $showTerminal)
+            case .team:
+                MinisTeamView { sessionID in
+                    pendingTeamSessionID = sessionID
+                    activeToolSheet = nil
+                }
             case .rootfsManagement:
                 NavigationStack {
                     RootfsManagementView()
@@ -3377,6 +3390,12 @@ struct ContentView: View {
         ToolbarItem(placement: .topBarTrailing) {
             if !isSelecting {
                 Menu {
+                    Button {
+                        activeToolSheet = .team
+                    } label: {
+                        Label("Bot 团队", systemImage: "person.3")
+                    }
+                    Divider()
                     Button {
                         showTerminal = true
                     } label: {

--- a/src/ios/Views/Settings/MountDetailView.swift
+++ b/src/ios/Views/Settings/MountDetailView.swift
@@ -247,20 +247,26 @@ struct MountDetailView: View {
 
     private var visibilitySection: some View {
         Section {
-            Toggle(isOn: $visibleInFiles) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Show in Files app")
-                    Text(visibleInFiles
-                         ? AppLocalized("This folder appears in Files → On My iPhone → Minis.")
-                         : AppLocalized("This folder is hidden from the iOS Files app."))
+            if !SharedContainerStore.isAppGroupAvailable {
+                Label("Shared access is unavailable. This folder is accessible inside Minis only.", systemImage: "info.circle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Toggle(isOn: $visibleInFiles) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show in Files app")
+                        Text(visibleInFiles
+                             ? AppLocalized("This folder appears in Files → On My iPhone → Minis.")
+                             : AppLocalized("This folder is hidden from the iOS Files app."))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if context.isReadOnlyFromFiles {
+                    Text("Read-only from the Files app. The app itself can always read and write.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
-            }
-            if context.isReadOnlyFromFiles {
-                Text("Read-only from the Files app. The app itself can always read and write.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
             }
         } header: {
             Text("Files app")
@@ -340,6 +346,7 @@ struct MountDetailView: View {
     }
 
     private func signalFileProviderRoot() {
+        guard SharedContainerStore.isAppGroupAvailable else { return }
         let domainIdentifier = NSFileProviderDomainIdentifier("com.openminis.app.files")
         NSFileProviderManager.getDomainsWithCompletionHandler { domains, _ in
             guard let domain = domains.first(where: { $0.identifier == domainIdentifier }) else {

--- a/src/ios/Views/Settings/SharedFoldersSettingsView.swift
+++ b/src/ios/Views/Settings/SharedFoldersSettingsView.swift
@@ -20,7 +20,9 @@ struct SharedFoldersSettingsView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Label("Shared folders", systemImage: "info.circle")
                         .font(.subheadline.weight(.semibold))
-                    Text("These directories appear in iOS Files under On My iPhone → Minis. Tap a row to see details, browse, or toggle visibility.")
+                    Text(SharedContainerStore.isAppGroupAvailable
+                         ? "These directories appear in iOS Files under On My iPhone → Minis. Tap a row to see details, browse, or toggle visibility."
+                         : "Shared access is unavailable with this signing configuration. These folders are stored privately on this device and can be browsed inside Minis. Files app integration and extension sharing are unavailable.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -111,7 +113,11 @@ private struct SharedFolderRow: View {
     /// Small pill showing whether Files app access is read/write or read-only.
     @ViewBuilder
     private var accessBadge: some View {
-        if entry.isWritableFromFiles {
+        if !SharedContainerStore.isAppGroupAvailable {
+            Text("In app only")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+        } else if entry.isWritableFromFiles {
             Text("R/W")
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(.green)
@@ -224,6 +230,7 @@ final class SharedFoldersViewModel: ObservableObject {
     }
 
     private static func signalFileProviderRoot() {
+        guard SharedContainerStore.isAppGroupAvailable else { return }
         let domainIdentifier = NSFileProviderDomainIdentifier("com.openminis.app.files")
         NSFileProviderManager.getDomainsWithCompletionHandler { domains, _ in
             guard let domain = domains.first(where: { $0.identifier == domainIdentifier }) else {

--- a/src/ios/Views/Team/MinisTeamView.swift
+++ b/src/ios/Views/Team/MinisTeamView.swift
@@ -1,0 +1,710 @@
+import SwiftUI
+
+/// Team orchestration uses the existing native Minis sessions and providers.
+/// The enclosing ContentView dismisses this sheet before navigating to a session.
+struct MinisTeamView: View {
+    let onOpenSession: (String) -> Void
+
+    @ObservedObject private var store = MinisTeamStore.shared
+    @ObservedObject private var providers = ProviderConfigStore.shared
+    @ObservedObject private var locks = SessionLockStore.shared
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
+    @State private var activeSheet: TeamSheet?
+    @State private var botToDelete: MinisBotProfile?
+    @State private var errorMessage: String?
+    @State private var activeTasksOnly = false
+
+    private enum TeamSheet: Identifiable {
+        case newBot
+        case editBot(MinisBotProfile)
+        case dispatch(String?)
+
+        var id: String {
+            switch self {
+            case .newBot: return "new-bot"
+            case .editBot(let bot): return "edit-\(bot.id)"
+            case .dispatch(let botID): return "dispatch-\(botID ?? "choose")"
+            }
+        }
+    }
+
+    private var visibleTasks: [MinisTeamTask] {
+        store.tasks
+            .filter { !activeTasksOnly || !$0.state.isTerminal }
+            .sorted { $0.createdAt > $1.createdAt }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List {
+                overviewSection
+                if let error = store.storageError {
+                    Section {
+                        Label(error, systemImage: "exclamationmark.triangle")
+                            .foregroundStyle(.red)
+                            .font(.footnote)
+                            .textSelection(.enabled)
+                    }
+                }
+                botsSection
+                tasksSection
+            }
+            .navigationTitle("Bot 团队")
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationDestination(for: String.self) { taskID in
+                MinisTeamTaskDetail(taskID: taskID, onOpenSession: onOpenSession)
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("完成") { dismiss() }
+                }
+                ToolbarItem(placement: .primaryAction) {
+                    Menu {
+                        Button {
+                            activeSheet = .newBot
+                        } label: {
+                            Label("新建 Bot", systemImage: "person.badge.plus")
+                        }
+                        Button {
+                            activeSheet = .dispatch(nil)
+                        } label: {
+                            Label("派发任务", systemImage: "paperplane")
+                        }
+                        .disabled(store.bots.isEmpty)
+                    } label: {
+                        Image(systemName: "plus")
+                    }
+                    .accessibilityLabel("添加 Bot 或任务")
+                }
+            }
+            .refreshable { await store.refresh() }
+            .sheet(item: $activeSheet) { sheet in
+                switch sheet {
+                case .newBot:
+                    MinisBotEditor(bot: nil)
+                case .editBot(let bot):
+                    MinisBotEditor(bot: bot)
+                case .dispatch(let botID):
+                    MinisTeamTaskComposer(initialBotID: botID)
+                }
+            }
+            .confirmationDialog(
+                "删除这个 Bot？",
+                isPresented: Binding(
+                    get: { botToDelete != nil },
+                    set: { if !$0 { botToDelete = nil } }
+                ),
+                titleVisibility: .visible,
+                presenting: botToDelete
+            ) { bot in
+                Button("删除 Bot", role: .destructive) {
+                    do {
+                        try store.deleteBot(id: bot.id)
+                    } catch {
+                        errorMessage = error.localizedDescription
+                    }
+                    botToDelete = nil
+                }
+                .disabled(bot.sessionID.map { locks.isVisuallyLocked($0) } ?? false)
+                Button("取消", role: .cancel) { botToDelete = nil }
+            } message: { _ in
+                Text("已创建的会话和任务记录会保留。")
+            }
+            .alert("操作未完成", isPresented: errorBinding) {
+                Button("好", role: .cancel) { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+        .task(id: scenePhase) {
+            guard scenePhase == .active else { return }
+            await store.refresh()
+            // Expiry must mask content even if no task changes while this sheet
+            // is open. No model requests or scheduler polling occur in this loop.
+            while !Task.isCancelled {
+                locks.evictIdleExpired()
+                do { try await Task.sleep(nanoseconds: 2_000_000_000) }
+                catch { return }
+            }
+        }
+    }
+
+    private var overviewSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 12) {
+                Label("把工作分给不同的 Bot", systemImage: "person.3.fill")
+                    .font(.headline)
+                Text("为每个 Bot 设定职责和模型，在各自的会话中持续处理任务。")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                HStack(spacing: 20) {
+                    countLabel("Bot", count: store.bots.count)
+                    countLabel("运行中", count: store.tasks.filter { $0.state == .running }.count)
+                    countLabel("排队中", count: store.tasks.filter { $0.state == .queued }.count)
+                }
+            }
+            .padding(.vertical, 5)
+        } footer: {
+            Text("任务由这台设备执行，最多同时处理 3 个；同一个 Bot 按顺序处理。锁屏或切到后台后，运行时间受 iOS 限制；应用重启后，未完成任务会标记为已中断。")
+        }
+    }
+
+    private func countLabel(_ title: String, count: Int) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("\(count)")
+                .font(.title3.weight(.semibold))
+                .monospacedDigit()
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var botsSection: some View {
+        Section("我的 Bot") {
+            if store.bots.isEmpty {
+                Text("还没有 Bot。先创建一个，并告诉它负责什么。")
+                    .foregroundStyle(.secondary)
+            }
+            ForEach(store.bots) { bot in
+                botRow(bot)
+            }
+            Button {
+                activeSheet = .newBot
+            } label: {
+                Label("新建 Bot", systemImage: "plus.circle")
+            }
+        }
+    }
+
+    private func botRow(_ bot: MinisBotProfile) -> some View {
+        let isLocked = bot.sessionID.map { locks.isVisuallyLocked($0) } ?? false
+        return HStack(spacing: 12) {
+            Image(systemName: isLocked ? "lock" : "person.crop.square")
+                .font(.title2)
+                .foregroundStyle(Color.accentColor)
+            Button {
+                if isLocked, let sessionID = bot.sessionID {
+                    onOpenSession(sessionID)
+                } else {
+                    activeSheet = .editBot(bot)
+                }
+            } label: {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(isLocked ? "已锁定的 Bot" : bot.name)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                    Text(isLocked ? "打开会话以解锁" : bot.role)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                    if !isLocked {
+                        Text(modelName(bot.modelEntryID))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.borderless)
+            .accessibilityLabel(isLocked ? "打开 Bot 会话解锁" : "编辑 \(bot.name)")
+            Button {
+                activeSheet = .dispatch(bot.id)
+            } label: {
+                Image(systemName: "paperplane")
+                    .padding(8)
+            }
+            .buttonStyle(.borderless)
+            .disabled(isLocked)
+            .accessibilityLabel(isLocked ? "Bot 已锁定" : "给 \(bot.name) 派发任务")
+        }
+        .padding(.vertical, 3)
+        .contextMenu {
+            if !isLocked {
+                Button {
+                    activeSheet = .editBot(bot)
+                } label: {
+                    Label("编辑 Bot", systemImage: "pencil")
+                }
+                Button {
+                    activeSheet = .dispatch(bot.id)
+                } label: {
+                    Label("派发任务", systemImage: "paperplane")
+                }
+            }
+            if let sessionID = bot.sessionID {
+                Button {
+                    onOpenSession(sessionID)
+                } label: {
+                    Label("打开会话", systemImage: "bubble.left.and.bubble.right")
+                }
+            }
+            if !isLocked {
+                Button(role: .destructive) {
+                    botToDelete = bot
+                } label: {
+                    Label("删除 Bot", systemImage: "trash")
+                }
+            }
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if !isLocked {
+                Button("删除", role: .destructive) { botToDelete = bot }
+                Button("编辑") { activeSheet = .editBot(bot) }
+                    .tint(.blue)
+            }
+        }
+    }
+
+    private var tasksSection: some View {
+        Section {
+            Toggle("只看进行中的任务", isOn: $activeTasksOnly)
+                .font(.subheadline)
+            if visibleTasks.isEmpty {
+                Text(activeTasksOnly ? "没有排队或运行中的任务。" : "还没有任务。点 Bot 旁的发送按钮开始。")
+                    .foregroundStyle(.secondary)
+                    .font(.subheadline)
+            }
+            ForEach(visibleTasks) { task in
+                let isLocked = store.isTaskContentLocked(task)
+                NavigationLink(value: task.id) {
+                    VStack(alignment: .leading, spacing: 7) {
+                        HStack {
+                            Text(isLocked ? "已锁定的任务" : (store.bot(id: task.botID)?.name ?? "已删除的 Bot"))
+                                .font(.subheadline.weight(.semibold))
+                            Spacer()
+                            MinisTeamTaskStatus(state: task.state)
+                        }
+                        Text(isLocked ? "打开相关会话解锁后查看内容。" : task.prompt)
+                            .font(.subheadline)
+                            .lineLimit(2)
+                        Text(task.createdAt, style: .date)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            if !store.bots.isEmpty {
+                Button {
+                    activeSheet = .dispatch(nil)
+                } label: {
+                    Label("派发任务", systemImage: "paperplane")
+                }
+            }
+        } header: {
+            Text("任务")
+        }
+    }
+
+    private func modelName(_ entryID: String?) -> String {
+        guard let entryID else { return "沿用会话模型" }
+        return providers.entry(for: entryID)?.model.displayName ?? "模型不可用，请编辑 Bot"
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(get: { errorMessage != nil }, set: { if !$0 { errorMessage = nil } })
+    }
+}
+
+private struct MinisBotEditor: View {
+    let bot: MinisBotProfile?
+    @ObservedObject private var store = MinisTeamStore.shared
+    @ObservedObject private var providers = ProviderConfigStore.shared
+    @ObservedObject private var locks = SessionLockStore.shared
+    @Environment(\.dismiss) private var dismiss
+    @State private var name: String
+    @State private var role: String
+    @State private var modelEntryID: String?
+    @State private var showModelPicker = false
+    @State private var errorMessage: String?
+
+    init(bot: MinisBotProfile?) {
+        self.bot = bot
+        _name = State(initialValue: bot?.name ?? "")
+        _role = State(initialValue: bot?.role ?? "")
+        _modelEntryID = State(initialValue: bot?.modelEntryID)
+    }
+
+    private var isBusy: Bool {
+        guard let bot else { return false }
+        return store.tasks.contains { $0.botID == bot.id && !$0.state.isTerminal }
+    }
+
+    private var canSave: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !role.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !isBusy
+            && !isLocked
+            && (modelEntryID.map { providers.entry(for: $0) != nil } ?? true)
+    }
+
+    private var isLocked: Bool {
+        guard let bot,
+              let sessionID = store.bot(id: bot.id)?.sessionID ?? bot.sessionID else { return false }
+        return locks.isVisuallyLocked(sessionID)
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                if isLocked {
+                    Label("Bot 会话已锁定，请先在聊天列表解锁。", systemImage: "lock")
+                } else {
+                    Section("名称") {
+                        TextField("例如：代码审查", text: $name)
+                    }
+                    Section {
+                        TextEditor(text: $role)
+                            .frame(minHeight: 150)
+                            .accessibilityLabel("Bot 的职责和工作要求")
+                    } header: {
+                        Text("职责")
+                    } footer: {
+                        Text("写明它负责什么、工作要求和输出格式。这些要求会用于这个 Bot 的任务。")
+                    }
+                    Section {
+                        Button {
+                            showModelPicker = true
+                        } label: {
+                            HStack {
+                                Text("模型")
+                                    .foregroundStyle(.primary)
+                                Spacer()
+                                Text(modelName)
+                                    .foregroundStyle(.secondary)
+                                    .multilineTextAlignment(.trailing)
+                                Image(systemName: "chevron.right")
+                                    .font(.caption)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                        if modelEntryID != nil {
+                            Button("沿用会话模型") { modelEntryID = nil }
+                        }
+                    } header: {
+                        Text("模型选择")
+                    } footer: {
+                        Text("使用 Minis 中已配置的模型和账户。未指定时，新 Bot 使用默认模型，已有 Bot 沿用会话当前选择。")
+                    }
+                    if isBusy {
+                        Section {
+                            Label("这个 Bot 还有未完成任务，完成或取消后才能修改。", systemImage: "clock")
+                                .font(.footnote)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+            .navigationTitle(bot == nil ? "新建 Bot" : "编辑 Bot")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存", action: save)
+                        .disabled(!canSave)
+                }
+            }
+            .sheet(isPresented: $showModelPicker) {
+                NavigationStack {
+                    UnifiedModelPicker(config: .init(
+                        title: "选择 Bot 模型",
+                        groupScope: .none,
+                        candidateFilter: {
+                            $0.model.capabilities.supportedModalities.contains([.textInput, .textOutput])
+                        },
+                        showGroups: false,
+                        currentEntryId: { modelEntryID },
+                        onSelect: { modelEntryID = $0.id }
+                    ))
+                }
+            }
+            .onChange(of: isLocked) { locked in
+                if locked { showModelPicker = false }
+            }
+            .alert("无法保存 Bot", isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("好", role: .cancel) { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+    }
+
+    private var modelName: String {
+        guard let modelEntryID else { return "沿用会话模型" }
+        return providers.entry(for: modelEntryID)?.model.displayName ?? "模型不可用，请重新选择"
+    }
+
+    private func save() {
+        guard !isLocked else {
+            errorMessage = "Bot 会话已锁定，请先解锁。"
+            return
+        }
+        do {
+            if let bot {
+                try store.updateBot(id: bot.id, name: name, role: role, modelEntryID: modelEntryID)
+            } else {
+                _ = try store.createBot(name: name, role: role, modelEntryID: modelEntryID)
+            }
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct MinisTeamTaskComposer: View {
+    @ObservedObject private var store = MinisTeamStore.shared
+    @ObservedObject private var locks = SessionLockStore.shared
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedBotID: String
+    @State private var prompt = ""
+    @State private var errorMessage: String?
+
+    init(initialBotID: String?) {
+        _selectedBotID = State(initialValue: initialBotID ?? "")
+    }
+
+    private func isLocked(_ bot: MinisBotProfile) -> Bool {
+        bot.sessionID.map { locks.isVisuallyLocked($0) } ?? false
+    }
+
+    private var selectedBotIsLocked: Bool {
+        store.bot(id: selectedBotID).map { isLocked($0) } ?? false
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("负责的 Bot") {
+                    Picker("Bot", selection: $selectedBotID) {
+                        Text("请选择 Bot").tag("")
+                        ForEach(store.bots) { bot in
+                            Text(isLocked(bot) ? "已锁定的 Bot" : bot.name).tag(bot.id)
+                        }
+                    }
+                    if let bot = store.bot(id: selectedBotID) {
+                        Text(isLocked(bot) ? "请先在聊天列表解锁这个 Bot 的会话。" : bot.role)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Section {
+                    if selectedBotIsLocked {
+                        Label("解锁 Bot 会话后可继续派发。", systemImage: "lock")
+                    } else {
+                        TextEditor(text: $prompt)
+                            .frame(minHeight: 200)
+                            .accessibilityLabel("任务内容")
+                    }
+                } header: {
+                    Text("任务内容")
+                } footer: {
+                    Text("描述目标、必要的背景和预期产出。任务会进入队列；同一个 Bot 会沿用已有会话。")
+                }
+            }
+            .navigationTitle("派发任务")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("派发", action: dispatch)
+                        .disabled(store.bot(id: selectedBotID) == nil
+                                  || selectedBotIsLocked
+                                  || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            .onAppear {
+                if selectedBotID.isEmpty, let first = store.bots.first {
+                    selectedBotID = first.id
+                }
+            }
+            .alert("无法派发任务", isPresented: Binding(
+                get: { errorMessage != nil },
+                set: { if !$0 { errorMessage = nil } }
+            )) {
+                Button("好", role: .cancel) { errorMessage = nil }
+            } message: {
+                Text(errorMessage ?? "")
+            }
+        }
+    }
+
+    private func dispatch() {
+        guard !selectedBotIsLocked else {
+            errorMessage = "Bot 会话已锁定，请先解锁。"
+            return
+        }
+        do {
+            _ = try store.dispatch(botID: selectedBotID, prompt: prompt)
+            dismiss()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}
+
+private struct MinisTeamTaskDetail: View {
+    let taskID: String
+    let onOpenSession: (String) -> Void
+    @ObservedObject private var store = MinisTeamStore.shared
+    @ObservedObject private var locks = SessionLockStore.shared
+    @State private var cancelling = false
+
+    var body: some View {
+        List {
+            if let task = store.task(id: taskID) {
+                let isLocked = store.isTaskContentLocked(task)
+                Section("任务状态") {
+                    HStack {
+                        Text(isLocked ? "已锁定的任务" : (store.bot(id: task.botID)?.name ?? "已删除的 Bot"))
+                            .font(.headline)
+                        Spacer()
+                        MinisTeamTaskStatus(state: task.state)
+                    }
+                    dateRow("创建时间", date: task.createdAt)
+                    if let startedAt = task.startedAt {
+                        dateRow("开始时间", date: startedAt)
+                    }
+                    if let finishedAt = task.finishedAt {
+                        dateRow("结束时间", date: finishedAt)
+                    }
+                }
+                if isLocked {
+                    Section {
+                        Label("相关会话已锁定，解锁后可查看任务内容。", systemImage: "lock")
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Section("任务内容") {
+                        Text(task.prompt)
+                            .textSelection(.enabled)
+                    }
+                    if let result = task.result, !result.isEmpty {
+                        Section("结果") {
+                            Text(result)
+                                .textSelection(.enabled)
+                        }
+                    }
+                    if let error = task.error, !error.isEmpty {
+                        Section("说明") {
+                            Text(error)
+                                .foregroundStyle(task.state == .failed ? Color.red : Color.secondary)
+                                .textSelection(.enabled)
+                        }
+                    }
+                }
+                if task.state == .running {
+                    Section {
+                        Label("任务执行中，可打开会话查看进度或处理权限请求。", systemImage: "bubble.left.and.bubble.right")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Section {
+                    if let sessionID = task.sessionID {
+                        Button {
+                            onOpenSession(sessionID)
+                        } label: {
+                            Label("打开 Bot 会话", systemImage: "bubble.left.and.bubble.right")
+                        }
+                    }
+                    if let sourceSessionID = task.sourceSessionID,
+                       sourceSessionID != task.sessionID,
+                       locks.isVisuallyLocked(sourceSessionID) {
+                        Button {
+                            onOpenSession(sourceSessionID)
+                        } label: {
+                            Label("打开来源会话解锁", systemImage: "lock.open")
+                        }
+                    }
+                    if !task.state.isTerminal {
+                        Button(role: .destructive) {
+                            cancelling = true
+                            Task {
+                                await store.cancel(taskID: taskID)
+                                cancelling = false
+                            }
+                        } label: {
+                            Label(cancelling ? "正在取消…" : "取消任务", systemImage: "stop.circle")
+                        }
+                        .disabled(cancelling || isLocked)
+                    }
+                }
+            } else {
+                Text("找不到这条任务记录。")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("任务详情")
+        .navigationBarTitleDisplayMode(.inline)
+        .refreshable { await store.refresh() }
+    }
+
+    private func dateRow(_ title: String, date: Date) -> some View {
+        HStack {
+            Text(title)
+            Spacer()
+            Text(date.formatted(date: .abbreviated, time: .shortened))
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+        }
+        .font(.caption)
+    }
+}
+
+private struct MinisTeamTaskStatus: View {
+    let state: MinisTeamTaskState
+
+    var body: some View {
+        Label(title, systemImage: symbol)
+            .font(.caption.weight(.medium))
+            .foregroundStyle(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.10), in: Capsule())
+            .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private var title: String {
+        switch state {
+        case .queued: return "排队中"
+        case .running: return "运行中"
+        case .completed: return "已完成"
+        case .failed: return "失败"
+        case .cancelled: return "已取消"
+        case .interrupted: return "已中断"
+        }
+    }
+
+    private var symbol: String {
+        switch state {
+        case .queued: return "clock"
+        case .running: return "arrow.triangle.2.circlepath"
+        case .completed: return "checkmark.circle"
+        case .failed: return "exclamationmark.circle"
+        case .cancelled: return "stop.circle"
+        case .interrupted: return "pause.circle"
+        }
+    }
+
+    private var color: Color {
+        switch state {
+        case .queued: return .orange
+        case .running: return .blue
+        case .completed: return .green
+        case .failed: return .red
+        case .cancelled: return .secondary
+        case .interrupted: return .orange
+        }
+    }
+}


### PR DESCRIPTION
This adds a native iOS Bot-team workflow and improves Codex OAuth model discovery and behavior when an App Group container is unavailable. The resulting iPhone build has been tested on a physical device by the submitter, who reported successful use of the changes.

I understand [CONTRIBUTING.md](https://github.com/OpenMinis/OpenMinis/blob/main/CONTRIBUTING.md) says this repository is a release mirror and does not accept pull requests. This is a draft reference for the tested implementation, with no assumption that it can be merged here. If there is a supported way to contribute these changes to the development tree, I would be interested in following it.

The changes are separated into three commits for review:

1. **Codex OAuth model discovery.** Fetch the authenticated model catalog with client version `0.153.4`, preserve model-provided reasoning effort, context and modality metadata, and cache results per account. Include `gpt-6-astra` in the offline fallback and retain saved model entries if discovery fails. Correct token expiry/account extraction, preserve account identity during refresh, protect against stale refresh results, and redact authentication errors. Model availability remains subject to the authenticated account and server response. Related to the client/model compatibility problem in #76.
2. **Native Bot teams and UI.** Add persistent Bots with separate chat sessions, a task queue with up to three concurrent tasks and serial execution per Bot, persisted task history, request-ID deduplication, and cancellation handling. Queued or running tasks are marked interrupted after an app restart instead of automatically replaying. Add a team screen for Bot configuration, model selection, task status and results, accessible from the existing app UI. Dispatch uses Minis' existing tool and permission flow. This addresses the parallel task-management part of #214 on iOS. Bots have separate chat histories but share the device's Linux filesystem and may share enabled memory; they are not isolated execution environments. Work depends on the app remaining active, and iOS background suspension is not bypassed. It is an original Swift implementation informed by Grokbot's multi-Bot organization; no Grokbot source or assets are included.
3. **Unavailable App Group handling.** Allow the main app to use local storage when its shared container is unavailable, with an explanatory settings message. Avoid registering or signaling an inaccessible Files domain, and return errors from extensions that cannot access shared storage. This does not grant entitlements or migrate data automatically between local and shared storage.

Validation performed on the final combined source:

- 12 standalone TeamStore tests passed using the real store implementation with platform stubs.
- 11 focused OAuth/catalog tests passed. These exercise parsing and compatibility logic, not live authentication against every account type.
- Full Xcode 26.2 Release build for `iphoneos` / `arm64` succeeded through GitHub Actions.
- All 35 changed source/test files in this branch match the SHA-256 manifest of that successful build; splitting the commits did not alter the final source. `git diff --check` passed.
- The submitter tested the resulting app on a physical iPhone and reported success. A device/iOS version and a per-feature test matrix have not been recorded, so this is a general device smoke-test report.

The focused tests can be rerun on macOS with Swift installed:

```sh
bash scripts/test_codex_oauth.sh
bash src/ios/Agent/Team/StandaloneTests/run.sh
```

The implementation and submission were developed with AI assistance. This proposal covers iOS; it does not include an Android implementation or a port of Grokbot's desktop runtime.
